### PR TITLE
Refactor homebrew tasks to use loop instead of with_items

### DIFF
--- a/roles/osx/tasks/homebrew.yml
+++ b/roles/osx/tasks/homebrew.yml
@@ -4,23 +4,26 @@
   community.general.homebrew_tap:
     name: "{{ item }}"
     state: present
-  with_items: "{{ homebrew_taps }}"
+  loop: "{{ homebrew_taps }}"
   tags: [osx]
 
 - name: Installing homebrew formulas
   community.general.homebrew:
-    name: "{{ homebrew_formulas }}"
+    name: "{{ item }}"
     state: present
+  loop: "{{ homebrew_formulas }}"
   tags: [osx]
 
 - name: Installing homebrew based LSPs
   community.general.homebrew:
-    name: "{{ homebrew_lsps }}"
+    name: "{{ item }}"
     state: present
+  loop: "{{ homebrew_lsps }}"
   tags: [osx]
 
 - name: Installing cask applications
   community.general.homebrew_cask:
-    name: "{{ homebrew_cask_applications }}"
+    name: "{{ item }}"
     state: present
+  loop: "{{ homebrew_cask_applications }}"
   tags: [osx]


### PR DESCRIPTION
By having loops instead all the list at once, allows to "skip" is an app already exists, instead of failing the whole task

I.E. If you already installed iTerm and after that you run _osx_, when it reaches _Installing cask applications_ it will fail all with  `(item=iterm2) => {"ansible_loop_var": "item", "changed": false, "item": "iterm2", "msg": "Error: It seems there is already an App at '/Applications/iTerm.app'."}`

With a loop, it "fails" but will continue with the next on the list.