### PR TITLE
docs(spec): add spec for repo-root CLAUDE.md (claude-context)

### DIFF
--- a/roles/osx/tasks/osx.yml
+++ b/roles/osx/tasks/osx.yml
@@ -41,8 +41,8 @@
         echo "$updated" > "$file"
         echo "CHANGED"
       fi
-  register: claude_settings
-  changed_when: "'CHANGED' in claude_settings.stdout"
+  register: osx_claude_settings
+  changed_when: "'CHANGED' in osx_claude_settings.stdout"
   tags: [osx]
 
 - name: Symlink Claude custom commands

--- a/specs/claude-context/design.md
+++ b/specs/claude-context/design.md
@@ -1,0 +1,120 @@
+# Dotfiles Repo-Root CLAUDE.md Design Decisions
+
+Decisions specific to introducing a tracked `CLAUDE.md` at the root of the dotfiles repo
+so that Claude Code sessions launched with `cwd = ~/dev/dotfiles` have the minimum
+non-obvious context they need to act correctly in this repo.
+
+## Template adaptation note
+
+This spec follows a four-file convention borrowed from another project of mine:
+`design.md` (decisions and rationale), `requirements.md` ("shall" language, no
+implementation details), `tasks.md` (implementation status), `test-spec.md` (test
+coverage by behavior). The dotfiles repo does not have a pre-existing `specs/` tree;
+this spec establishes one under `specs/claude-context/`. The convention is
+borrowed wholesale with no structural changes. If more specs land in this repo later,
+a `specs/README.md` index can be added then.
+
+## Status
+
+- **Wave:** C (plan-only). Nothing in Wave C has been implemented yet, including
+  this item. This spec captures the resolved plan; the actual repo-root `CLAUDE.md`
+  has not been written.
+- **Decisions resolved:** 2026-04-07.
+- **Source plan:** improvement-plan item #11 in
+  `~/.claude/plans/zippy-pondering-planet.md` (section `[11/18]`). This spec is the
+  durable form of that plan section, so the plan doc can be deleted or rewritten
+  without losing context.
+
+## Context
+
+Source: improvement-plan item #11, originally framed as "dotfiles project memory"
+(an entry under `~/.claude/projects/-Users-inkatze-dev-dotfiles/memory/`). Wave B of
+the analysis surfaced no evidence for the original framing — hot-file re-reads were
+project source in tecpan/paycalc, not dotfiles config — and the global
+`~/.claude/CLAUDE.md` "What NOT to save in memory" rules forbid what-memory about
+file paths, project structure, and architecture. A naive project memory would have
+violated policy.
+
+The reframe: write a tracked `CLAUDE.md` at the dotfiles repo root instead. CLAUDE.md
+is the purpose-built, auto-loaded mechanism for repo-scoped ambient context, and does
+not run afoul of memory rules.
+
+## Mechanism: repo-root CLAUDE.md, not memory
+
+The file lives at `/Users/inkatze/dev/dotfiles/CLAUDE.md`, tracked in git, and is
+**not** symlinked into `~/.claude/`. It is about *this repo*, not about the global
+Claude config. Claude Code auto-loads it whenever a session is started with cwd inside
+this repo, which is the only mechanism needed — no Ansible task, no symlink, no
+memory entry.
+
+## Scope gate (three-part test)
+
+A fact qualifies for inclusion only if it satisfies **all three** of:
+
+1. Non-obvious from a quick `ls` or `cat .mise.toml` in the repo root.
+2. Not already covered by global `~/.claude/CLAUDE.md`.
+3. Would change how Claude acts when working in this repo.
+
+Anything that fails any leg of the test is excluded. The point is restraint: every
+section must earn its keep, and the file must stay short enough to remain useful
+context rather than become noise.
+
+## Explicit excludes
+
+- Fish shell usage notes — already in global CLAUDE.md.
+- mise usage notes — already in global CLAUDE.md.
+- Conventional-commit / no-Claude-footer / explicit-remote-on-push rules — already
+  in global CLAUDE.md.
+- Ansible tutorial content. Claude can read Ansible docs on demand.
+- Full file-tree dumps or role inventories. Claude can `ls` on demand.
+
+## Content ordering: decision-oriented, not inventory-oriented
+
+Each section answers "when you're about to do X, know Y" rather than "here is what
+the repo contains." Inventory belongs in the filesystem; CLAUDE.md is for the
+non-derivable rules and gotchas that shape behavior.
+
+## Soft dependency on #8 (three-layer permissions model)
+
+Improvement-plan item #8 resolves the three-layer permissions model
+(global tracked, per-repo tracked, per-repo local). One of CLAUDE.md's key sections
+is a compact restatement of that model so Claude knows where new permissions belong.
+
+This spec **consumes** #8's decisions; it does not duplicate or restate them in
+detail. If #8's model changes during implementation, the corresponding CLAUDE.md
+section is updated to match. The dependency is soft because #8 is already planned
+in Wave A — drafting the section here can proceed against the planned model even
+if #8 has not yet shipped.
+
+Reference: see improvement-plan item #8 in
+`~/.claude/plans/zippy-pondering-planet.md` for the full three-layer reasoning.
+
+## No memory file is created
+
+The existing entry at `project_improvement_plan.md` in memory remains untouched.
+No new `project_dotfiles_structure.md` or similar is created as part of this work.
+If a future decision or incident genuinely fits a memory type (project / feedback /
+reference), it can be added then on its own merit, not bundled with this item.
+
+## Decision log
+
+- **Reframed from project memory to repo-root CLAUDE.md.** Original framing
+  ("dotfiles project memory") would have violated the global memory policy's
+  prohibition on what-memory about file paths, project structure, and architecture.
+  CLAUDE.md is the purpose-built mechanism for the same job and carries no such
+  policy conflict.
+- **Repo-root, tracked in git, not symlinked into `~/.claude/`.** It is about
+  *this repo*, not about global Claude config. Auto-load handles the rest; no
+  Ansible task needed.
+- **Scope gated by the three-part test.** Non-obvious AND not in global CLAUDE.md
+  AND behavior-changing. All three legs required, no exceptions.
+- **Consumes #8's three-layer permissions model; does not duplicate it.** The
+  CLAUDE.md section for permissions is a compact restatement, not a re-derivation.
+  If #8's model changes, this file follows.
+- **Soft dependency on #8 (planned, not necessarily shipped).** Already satisfied:
+  #8 is in Wave A.
+- **No new memory file created.** Existing `project_improvement_plan.md` memory
+  entry is untouched. Future memory entries, if any, must earn their place on
+  their own merit, not as part of this item.
+- **Effort estimate: XS–S, ~30 minutes.** Most of the effort is restraint —
+  resisting the urge to dump structure that Claude can derive from a quick `ls`.

--- a/specs/claude-context/design.md
+++ b/specs/claude-context/design.md
@@ -22,8 +22,11 @@ a `specs/README.md` index can be added then.
 - **Decisions resolved:** 2026-04-07.
 - **Source plan:** improvement-plan item #11 in
   `~/.claude/plans/zippy-pondering-planet.md` (section `[11/18]`). This spec is the
-  durable form of that plan section, so the plan doc can be deleted or rewritten
-  without losing context.
+  durable form of that plan section for #11's own substance. The one external
+  dependency is #8's three-layer permissions reasoning (see "Soft dependency on
+  #8" below): once #8 has its own spec, the plan doc can be deleted without
+  losing context. Until then, the plan doc remains the only durable record of
+  #8's full rationale.
 
 ## Context
 

--- a/specs/claude-context/design.md
+++ b/specs/claude-context/design.md
@@ -1,8 +1,8 @@
 # Dotfiles Repo-Root CLAUDE.md Design Decisions
 
 Decisions specific to introducing a tracked `CLAUDE.md` at the root of the dotfiles repo
-so that Claude Code sessions launched with `cwd = ~/dev/dotfiles` have the minimum
-non-obvious context they need to act correctly in this repo.
+so that Claude Code sessions launched with cwd at the dotfiles repo root have the
+minimum non-obvious context they need to act correctly in this repo.
 
 ## Template adaptation note
 

--- a/specs/claude-context/design.md
+++ b/specs/claude-context/design.md
@@ -50,7 +50,7 @@ memory entry.
 
 A fact qualifies for inclusion only if it satisfies **all three** of:
 
-1. Non-obvious from a quick `ls` or `cat .mise.toml` in the repo root.
+1. Non-obvious from a quick `ls` or `cat mise.toml` in the repo root.
 2. Not already covered by global `~/.claude/CLAUDE.md`.
 3. Would change how Claude acts when working in this repo.
 

--- a/specs/claude-context/design.md
+++ b/specs/claude-context/design.md
@@ -27,7 +27,7 @@ a `specs/README.md` index can be added then.
 ## Context
 
 Source: improvement-plan item #11, originally framed as "dotfiles project memory"
-(an entry under `~/.claude/projects/-Users-inkatze-dev-dotfiles/memory/`). Wave B of
+(an entry in the Claude per-project memory directory for this repo). Wave B of
 the analysis surfaced no evidence for the original framing — hot-file re-reads were
 project source in tecpan/paycalc, not dotfiles config — and the global
 `~/.claude/CLAUDE.md` "What NOT to save in memory" rules forbid what-memory about
@@ -40,7 +40,7 @@ not run afoul of memory rules.
 
 ## Mechanism: repo-root CLAUDE.md, not memory
 
-The file lives at `/Users/inkatze/dev/dotfiles/CLAUDE.md`, tracked in git, and is
+The file lives at `CLAUDE.md` in the dotfiles repo root, tracked in git, and is
 **not** symlinked into `~/.claude/`. It is about *this repo*, not about the global
 Claude config. Claude Code auto-loads it whenever a session is started with cwd inside
 this repo, which is the only mechanism needed — no Ansible task, no symlink, no

--- a/specs/claude-context/design.md
+++ b/specs/claude-context/design.md
@@ -7,9 +7,9 @@ minimum non-obvious context they need to act correctly in this repo.
 ## Template adaptation note
 
 This spec follows a four-file convention borrowed from another project of mine:
-`design.md` (decisions and rationale), `requirements.md` ("shall" language, no
-implementation details), `tasks.md` (implementation status), `test-spec.md` (test
-coverage by behavior). The dotfiles repo does not have a pre-existing `specs/` tree;
+`design.md` (decisions and rationale), `requirements.md` ("shall" language,
+behavior and constraints, with occasional repo-specific references where needed),
+`tasks.md` (implementation status), `test-spec.md` (test coverage by behavior). The dotfiles repo does not have a pre-existing `specs/` tree;
 this spec establishes one under `specs/claude-context/`. The convention is
 borrowed wholesale with no structural changes. If more specs land in this repo later,
 a `specs/README.md` index can be added then.

--- a/specs/claude-context/design.md
+++ b/specs/claude-context/design.md
@@ -20,13 +20,9 @@ a `specs/README.md` index can be added then.
   this item. This spec captures the resolved plan; the actual repo-root `CLAUDE.md`
   has not been written.
 - **Decisions resolved:** 2026-04-07.
-- **Source plan:** improvement-plan item #11 in
-  `~/.claude/plans/zippy-pondering-planet.md` (section `[11/18]`). This spec is the
-  durable form of that plan section for #11's own substance. The one external
-  dependency is #8's three-layer permissions reasoning (see "Soft dependency on
-  #8" below): once #8 has its own spec, the plan doc can be deleted without
-  losing context. Until then, the plan doc remains the only durable record of
-  #8's full rationale.
+- **Source plan:** improvement-plan item #11. This spec is the durable form of
+  that plan item for #11's own substance. The one external dependency is #8's
+  three-layer permissions reasoning (see "Soft dependency on #8" below).
 
 ## Context
 
@@ -88,9 +84,6 @@ detail. If #8's model changes during implementation, the corresponding CLAUDE.md
 section is updated to match. The dependency is soft because #8 is already planned
 in Wave A — drafting the section here can proceed against the planned model even
 if #8 has not yet shipped.
-
-Reference: see improvement-plan item #8 in
-`~/.claude/plans/zippy-pondering-planet.md` for the full three-layer reasoning.
 
 ## No memory file is created
 

--- a/specs/claude-context/requirements.md
+++ b/specs/claude-context/requirements.md
@@ -2,8 +2,7 @@
 
 ## File location and tracking
 
-- The system shall provide a `CLAUDE.md` file at the root of the dotfiles repo
-  (`/Users/inkatze/dev/dotfiles/CLAUDE.md`).
+- The system shall provide a `CLAUDE.md` file at the root of the dotfiles repo.
 - The file shall be tracked in git.
 - The file shall **not** be symlinked into `~/.claude/`. It is repo-scoped context,
   not global Claude config.
@@ -28,8 +27,8 @@
 
 ## Required content
 
-The file shall contain, at minimum, the following sections (omit any that turn out
-to have nothing non-obvious to say):
+The file should include the following sections when they satisfy the scope gate and
+have something non-obvious to say; sections that do not may be omitted:
 
 - **What this repo is.** One paragraph identifying the repo as personal dotfiles,
   Ansible-managed, source of truth for `~/.claude/*`, `~/.config/fish/*`, tmux,

--- a/specs/claude-context/requirements.md
+++ b/specs/claude-context/requirements.md
@@ -20,7 +20,7 @@
 ## Scope gate
 
 - Each fact in the file shall satisfy all three of:
-  1. Non-obvious from a quick `ls` or `cat .mise.toml` in the repo root.
+  1. Non-obvious from a quick `ls` or `cat mise.toml` in the repo root.
   2. Not already covered by global `~/.claude/CLAUDE.md`.
   3. Would change how Claude acts when working in this repo.
 - Facts that fail any leg of the test shall be excluded.
@@ -37,7 +37,9 @@ have something non-obvious to say; sections that do not may be omitted:
 - **How Claude config is materialized.** The non-obvious fact that files under
   `roles/osx/files/claude/` are the tracked source of truth and Ansible symlinks
   them into `~/.claude/`. Editing the symlink target directly is wrong; edit the
-  tracked source file. Applies equally to commands, skills, and hooks.
+  tracked source file. Today this covers `commands/` and `settings.json`; adding
+  new surfaces (skills, hooks) requires creating the tracked directory and a
+  matching symlink task in `roles/osx/tasks/osx.yml`.
 - **Permissions three-layer model.** A compact restatement of #8's decision:
   global `~/.claude/settings.json` (tracked via this repo) for durable cross-project
   allows plus the deny list; per-repo tracked `.claude/settings.json` for
@@ -45,10 +47,11 @@ have something non-obvious to say; sections that do not may be omitted:
   ephemeral, short, nukeable rules. Note that for the dotfiles repo itself, the
   tracked `.claude/settings.json` (created in #8) holds dotfiles-specific durable
   rules and the local file should stay near-empty.
-- **Adding a new Claude command, skill, or hook.** The path and propagation:
-  drop the file under `roles/osx/files/claude/{commands,skills,hooks}/`, commit,
-  let the Ansible symlink task pick it up, verify in a fresh session. Note that
-  `SKILL.md` and command front-matter are required for discovery.
+- **Adding a new Claude command.** The path and propagation: drop the file under
+  `roles/osx/files/claude/commands/`, commit, let the Ansible symlink task pick
+  it up, verify in a fresh session. Command front-matter is required for
+  discovery. Adding skills or hooks is out of scope for this section until those
+  surfaces are managed by Ansible (new tracked directory plus symlink task).
 - **Things to NOT edit directly in `~/.claude/`.** Anything symlinked from this
   repo. If in doubt, `readlink` the file first.
 - **Ansible role layout pointer.** A single-line hint that `roles/osx/` is the Mac

--- a/specs/claude-context/requirements.md
+++ b/specs/claude-context/requirements.md
@@ -1,0 +1,80 @@
+# Dotfiles Repo-Root CLAUDE.md Requirements
+
+## File location and tracking
+
+- The system shall provide a `CLAUDE.md` file at the root of the dotfiles repo
+  (`/Users/inkatze/dev/dotfiles/CLAUDE.md`).
+- The file shall be tracked in git.
+- The file shall **not** be symlinked into `~/.claude/`. It is repo-scoped context,
+  not global Claude config.
+- The file shall not require any Ansible task to be run for it to take effect.
+  Claude Code's built-in CLAUDE.md auto-load behavior is the only mechanism.
+
+## Size and shape
+
+- The file shall be no longer than 120 lines.
+- The file shall be organized into short, decision-oriented sections, each answering
+  "when you're about to do X, know Y."
+- Sections shall be omitted rather than padded if they have nothing non-obvious to
+  say.
+
+## Scope gate
+
+- Each fact in the file shall satisfy all three of:
+  1. Non-obvious from a quick `ls` or `cat .mise.toml` in the repo root.
+  2. Not already covered by global `~/.claude/CLAUDE.md`.
+  3. Would change how Claude acts when working in this repo.
+- Facts that fail any leg of the test shall be excluded.
+
+## Required content
+
+The file shall contain, at minimum, the following sections (omit any that turn out
+to have nothing non-obvious to say):
+
+- **What this repo is.** One paragraph identifying the repo as personal dotfiles,
+  Ansible-managed, source of truth for `~/.claude/*`, `~/.config/fish/*`, tmux,
+  mise, and similar. Explains the mental model: edits land in this repo, an Ansible
+  run propagates them.
+- **How Claude config is materialized.** The non-obvious fact that files under
+  `roles/osx/files/claude/` are the tracked source of truth and Ansible symlinks
+  them into `~/.claude/`. Editing the symlink target directly is wrong; edit the
+  tracked source file. Applies equally to commands, skills, and hooks.
+- **Permissions three-layer model.** A compact restatement of #8's decision:
+  global `~/.claude/settings.json` (tracked via this repo) for durable cross-project
+  allows plus the deny list; per-repo tracked `.claude/settings.json` for
+  project-specific durable allows; per-repo `.claude/settings.local.json` for
+  ephemeral, short, nukeable rules. Note that for the dotfiles repo itself, the
+  tracked `.claude/settings.json` (created in #8) holds dotfiles-specific durable
+  rules and the local file should stay near-empty.
+- **Adding a new Claude command, skill, or hook.** The path and propagation:
+  drop the file under `roles/osx/files/claude/{commands,skills,hooks}/`, commit,
+  let the Ansible symlink task pick it up, verify in a fresh session. Note that
+  `SKILL.md` and command front-matter are required for discovery.
+- **Things to NOT edit directly in `~/.claude/`.** Anything symlinked from this
+  repo. If in doubt, `readlink` the file first.
+- **Ansible role layout pointer.** A single-line hint that `roles/osx/` is the Mac
+  role, most Claude-related files live under `roles/osx/files/claude/`, and
+  `roles/osx/tasks/` contains the symlink tasks. Deliberately not a full tree dump.
+
+## Excluded content
+
+The file shall **not** contain:
+
+- Fish shell or mise usage notes (already in global CLAUDE.md).
+- Conventional-commit, no-Claude-footer, GPG-signing, or explicit-remote-on-push
+  rules (already in global CLAUDE.md).
+- Ansible tutorial content.
+- Full file-tree dumps or role inventories.
+- A "Git conventions specific to this repo" section unless conventions actually
+  diverge from the global rules. Omit rather than pad.
+
+## Memory system
+
+- No new memory file shall be created as part of this work.
+- The existing `project_improvement_plan.md` memory entry shall remain untouched.
+
+## Dependency on #8
+
+- The "Permissions three-layer model" section shall consume #8's decisions without
+  duplicating their full reasoning.
+- If #8's model changes during implementation, this file shall be updated to match.

--- a/specs/claude-context/requirements.md
+++ b/specs/claude-context/requirements.md
@@ -31,15 +31,19 @@ The file should include the following sections when they satisfy the scope gate 
 have something non-obvious to say; sections that do not may be omitted:
 
 - **What this repo is.** One paragraph identifying the repo as personal dotfiles,
-  Ansible-managed, source of truth for `~/.claude/*`, `~/.config/fish/*`, tmux,
-  mise, and similar. Explains the mental model: edits land in this repo, an Ansible
-  run propagates them.
-- **How Claude config is materialized.** The non-obvious fact that files under
-  `roles/osx/files/claude/` are the tracked source of truth and Ansible symlinks
-  them into `~/.claude/`. Editing the symlink target directly is wrong; edit the
-  tracked source file. Today this covers `commands/` and `settings.json`; adding
-  new surfaces (skills, hooks) requires creating the tracked directory and a
-  matching symlink task in `roles/osx/tasks/osx.yml`.
+  Ansible-managed, source of truth for the managed parts of `~/.claude/`,
+  `~/.config/fish/*`, tmux, mise, and similar. Explains the mental model: edits
+  land in this repo, an Ansible run propagates them.
+- **How Claude config is materialized.** The non-obvious fact that the tracked
+  Claude sources live in the Ansible role and are materialized by different
+  mechanisms: `roles/osx/files/claude/commands/` is symlinked into
+  `~/.claude/commands/`, `~/.claude/CLAUDE.md` is symlinked from
+  `roles/osx/files/CLAUDE.md` (note: outside the `claude/` directory), and
+  `roles/osx/files/claude/settings.json` is merged into `~/.claude/settings.json`
+  by a jq-based task rather than symlinked. Editing the materialized file
+  directly is wrong; edit the tracked source. Adding new surfaces (skills, hooks)
+  requires creating the tracked directory and matching management in
+  `roles/osx/tasks/osx.yml`.
 - **Permissions three-layer model.** A compact restatement of #8's decision:
   global `~/.claude/settings.json` (tracked via this repo) for durable cross-project
   allows plus the deny list; per-repo tracked `.claude/settings.json` for

--- a/specs/claude-context/requirements.md
+++ b/specs/claude-context/requirements.md
@@ -68,6 +68,12 @@ The file shall **not** contain:
 - A "Git conventions specific to this repo" section unless conventions actually
   diverge from the global rules. Omit rather than pad.
 
+## Files modified
+
+- No files outside the new `CLAUDE.md` (and this spec directory) shall be modified
+  as part of this work. The existing global `~/.claude/CLAUDE.md` is not touched;
+  there is no duplication.
+
 ## Memory system
 
 - No new memory file shall be created as part of this work.

--- a/specs/claude-context/tasks.md
+++ b/specs/claude-context/tasks.md
@@ -20,9 +20,9 @@ Target 60–120 lines. Sections, in order:
    `.claude/settings.json` (tracked, created in #8) holds dotfiles-specific durable
    rules; `.claude/settings.local.json` should stay near-empty.
 4. **Adding a new Claude command / skill / hook** — drop the file under
-   `roles/osx/files/claude/{commands,skills,hooks}/`, commit, let the Ansible
-   symlink task pick it up, verify in a fresh session. Front-matter / `SKILL.md`
-   required for discovery.
+   `roles/osx/files/claude/{commands,skills,hooks}/`, commit, run Ansible (or
+   let the symlink task pick it up on its next run), verify in a fresh session.
+   Front-matter / `SKILL.md` required for discovery.
 5. **Things to NOT edit directly in `~/.claude/`** — anything symlinked from this
    repo. If in doubt, `readlink` first.
 6. **Ansible role layout pointer** — one line: `roles/osx/` is the Mac role; most

--- a/specs/claude-context/tasks.md
+++ b/specs/claude-context/tasks.md
@@ -19,10 +19,12 @@ Target 60–120 lines. Sections, in order:
    (global tracked, per-repo tracked, per-repo local). Note that the dotfiles
    `.claude/settings.json` (tracked, created in #8) holds dotfiles-specific durable
    rules; `.claude/settings.local.json` should stay near-empty.
-4. **Adding a new Claude command / skill / hook** — drop the file under
-   `roles/osx/files/claude/{commands,skills,hooks}/`, commit, run Ansible (or
-   let the symlink task pick it up on its next run), verify in a fresh session.
-   Front-matter / `SKILL.md` required for discovery.
+4. **Adding a new Claude command** — drop the file under
+   `roles/osx/files/claude/commands/`, commit, run Ansible (or let the symlink
+   task pick it up on its next run), verify in a fresh session. Command
+   front-matter required for discovery. Skills/hooks are not currently managed
+   by Ansible; adding them would require a new tracked directory plus a matching
+   symlink task and is out of scope here.
 5. **Things to NOT edit directly in `~/.claude/`** — anything symlinked from this
    repo. If in doubt, `readlink` first.
 6. **Ansible role layout pointer** — one line: `roles/osx/` is the Mac role; most

--- a/specs/claude-context/tasks.md
+++ b/specs/claude-context/tasks.md
@@ -6,7 +6,7 @@ Tasks are ordered by dependency.
 
 ### 1. Draft `CLAUDE.md` at the dotfiles repo root
 
-Create `/Users/inkatze/dev/dotfiles/CLAUDE.md`, tracked in git, not symlinked.
+Create `CLAUDE.md` at the dotfiles repo root, tracked in git, not symlinked.
 Target 60–120 lines. Sections, in order:
 
 1. **What this repo is** — one paragraph: personal dotfiles, Ansible-managed,

--- a/specs/claude-context/tasks.md
+++ b/specs/claude-context/tasks.md
@@ -42,15 +42,18 @@ Apply the three-part scope gate (see `design.md`) to every line. Soft dependency
 
 ### 2. Verify in a fresh Claude session
 
-See `test-spec.md` for the verification checklist. No code or config changes; this
-task gates the commit on a manual fresh-session smoke test.
+See `test-spec.md` for the verification checklist. Using the `CLAUDE.md` drafted in
+step 1, make no additional code or config changes during this step; it gates the
+commit on a manual fresh-session smoke test before committing.
 
 ### 3. Commit on a feature branch
 
-Conventional-commit message, no Claude footer, no co-author trailer, GPG signed,
-explicit remote on push. Example: `docs(claude): add repo-root CLAUDE.md`. Do not
-push or open a PR as part of the spec work; that happens when the implementation
-task lands.
+Conventional-commit message, no Claude footer, no co-author trailer, GPG signed.
+Example: `docs(claude): add repo-root CLAUDE.md`. For this task, make the commit
+locally on your feature branch only. The push and PR for the implementation work
+happen later, as part of that implementation workflow, not as part of this task
+(this restriction is about the implementation step itself, not about the spec PR
+that introduces these documents).
 
 ## Effort
 

--- a/specs/claude-context/tasks.md
+++ b/specs/claude-context/tasks.md
@@ -1,0 +1,56 @@
+# Dotfiles Repo-Root CLAUDE.md Implementation Status
+
+## Task order
+
+Tasks are ordered by dependency.
+
+### 1. Draft `CLAUDE.md` at the dotfiles repo root
+
+Create `/Users/inkatze/dev/dotfiles/CLAUDE.md`, tracked in git, not symlinked.
+Target 60–120 lines. Sections, in order:
+
+1. **What this repo is** — one paragraph: personal dotfiles, Ansible-managed,
+   source of truth for `~/.claude/*`, `~/.config/fish/*`, tmux, mise. Mental model:
+   edits land here, Ansible run propagates.
+2. **How Claude config is materialized** — files under
+   `roles/osx/files/claude/` are the tracked source of truth; Ansible symlinks them
+   into `~/.claude/`. Edit the tracked source, not the symlink target.
+3. **Permissions three-layer model** — compact restatement of #8's resolved model
+   (global tracked, per-repo tracked, per-repo local). Note that the dotfiles
+   `.claude/settings.json` (tracked, created in #8) holds dotfiles-specific durable
+   rules; `.claude/settings.local.json` should stay near-empty.
+4. **Adding a new Claude command / skill / hook** — drop the file under
+   `roles/osx/files/claude/{commands,skills,hooks}/`, commit, let the Ansible
+   symlink task pick it up, verify in a fresh session. Front-matter / `SKILL.md`
+   required for discovery.
+5. **Things to NOT edit directly in `~/.claude/`** — anything symlinked from this
+   repo. If in doubt, `readlink` first.
+6. **Ansible role layout pointer** — one line: `roles/osx/` is the Mac role; most
+   Claude-related files live under `roles/osx/files/claude/` and `roles/osx/tasks/`
+   has the symlink tasks. Not a full tree dump.
+7. **Git conventions specific to this repo** — only if any actually differ from
+   global. Likely none, in which case omit the section rather than pad.
+
+Apply the three-part scope gate (see `design.md`) to every line. Soft dependency:
+#8 must be planned (not necessarily shipped). Already satisfied — #8 is in Wave A.
+
+### 2. Verify in a fresh Claude session
+
+See `test-spec.md` for the verification checklist. No code or config changes; this
+task gates the commit on a manual fresh-session smoke test.
+
+### 3. Commit on a feature branch
+
+Conventional-commit message, no Claude footer, no co-author trailer, GPG signed,
+explicit remote on push. Example: `docs(claude): add repo-root CLAUDE.md`. Do not
+push or open a PR as part of the spec work; that happens when the implementation
+task lands.
+
+## Effort
+
+**XS–S** — ~30 minutes total to draft, verify, and commit. Most of the effort is
+restraint: resisting the urge to dump structure that Claude can derive on its own.
+
+## Rollback
+
+`git rm CLAUDE.md` in the dotfiles repo. No other surfaces are touched.

--- a/specs/claude-context/tasks.md
+++ b/specs/claude-context/tasks.md
@@ -10,11 +10,15 @@ Create `CLAUDE.md` at the dotfiles repo root, tracked in git, not symlinked.
 Target 60–120 lines. Sections, in order:
 
 1. **What this repo is** — one paragraph: personal dotfiles, Ansible-managed,
-   source of truth for `~/.claude/*`, `~/.config/fish/*`, tmux, mise. Mental model:
+   source of truth for the managed parts of `~/.claude/` (`~/.claude/CLAUDE.md`,
+   `settings.json`, `commands/`), `~/.config/fish/*`, tmux, mise. Mental model:
    edits land here, Ansible run propagates.
-2. **How Claude config is materialized** — files under
-   `roles/osx/files/claude/` are the tracked source of truth; Ansible symlinks them
-   into `~/.claude/`. Edit the tracked source, not the symlink target.
+2. **How Claude config is materialized** — tracked Claude sources live in the
+   Ansible role: `roles/osx/files/claude/commands/` is symlinked into
+   `~/.claude/commands/`, `~/.claude/CLAUDE.md` is symlinked from
+   `roles/osx/files/CLAUDE.md` (outside the `claude/` directory), and
+   `settings.json` is produced by a jq merge/write task rather than symlinked.
+   Edit the tracked source, not the materialized file in `~/.claude/`.
 3. **Permissions three-layer model** — compact restatement of #8's resolved model
    (global tracked, per-repo tracked, per-repo local). Note that the dotfiles
    `.claude/settings.json` (tracked, created in #8) holds dotfiles-specific durable

--- a/specs/claude-context/test-spec.md
+++ b/specs/claude-context/test-spec.md
@@ -38,7 +38,7 @@ fresh-session smoke test plus structural spot checks against the requirements.
 ### Git diff hygiene
 
 - The implementation commit touches only the new `CLAUDE.md` (and, for the spec
-  itself, only the files under `specs/dotfiles-claude-md/`). No stray edits to
+  itself, only the files under `specs/claude-context/`). No stray edits to
   unrelated config, roles, or settings files.
 
 ### Memory hygiene

--- a/specs/claude-context/test-spec.md
+++ b/specs/claude-context/test-spec.md
@@ -1,0 +1,56 @@
+# Dotfiles Repo-Root CLAUDE.md Test Specification
+
+## What to verify
+
+There is no automated test surface for a CLAUDE.md file. Verification is by
+fresh-session smoke test plus structural spot checks against the requirements.
+
+### Auto-load
+
+- A fresh Claude session launched with `cwd = /Users/inkatze/dev/dotfiles` shows the
+  new `CLAUDE.md` in its loaded context. The system reminder at session start cites
+  the file path.
+- Sessions launched with cwd outside the dotfiles repo do **not** load the file
+  (sanity check that it is repo-scoped, not global).
+
+### Behavioral checks (fresh session, cwd in dotfiles)
+
+- Asked "where do I add a new slash command?", Claude points to
+  `roles/osx/files/claude/commands/`, not `~/.claude/commands/`.
+- Asked "edit my commit command", Claude edits the tracked source file under
+  `roles/osx/files/claude/commands/`, not the symlink target in `~/.claude/`.
+- Asked where a new durable permission belongs, Claude can map the request to the
+  correct layer of the three-layer model (global tracked, per-repo tracked, per-repo
+  local) without re-deriving it from scratch.
+
+### Structural spot checks
+
+- File length is ≤ 120 lines.
+- No section duplicates content already in `~/.claude/CLAUDE.md` (Fish, mise,
+  conventional commits, no-Claude-footer, GPG signing, explicit-remote-on-push).
+- No Ansible tutorial content.
+- No full file-tree dumps or role inventories.
+- Every section earns its keep against the three-part scope gate from `design.md`.
+  Sections that fail the gate are removed rather than rewritten.
+- The "Permissions three-layer model" section is a compact restatement, not a
+  re-derivation, of #8's decision.
+
+### Git diff hygiene
+
+- The implementation commit touches only the new `CLAUDE.md` (and, for the spec
+  itself, only the files under `specs/dotfiles-claude-md/`). No stray edits to
+  unrelated config, roles, or settings files.
+
+### Memory hygiene
+
+- No new file is created under
+  `~/.claude/projects/-Users-inkatze-dev-dotfiles/memory/` as part of this work.
+- The existing `project_improvement_plan.md` memory entry is unchanged.
+
+## Out of scope
+
+- Performance, latency, or context-window measurements. CLAUDE.md is small and
+  loaded once per session; no measurement is meaningful at this size.
+- Verifying #8's permissions model itself. That belongs to #8's own test spec.
+  This spec only verifies that the model is referenced correctly, not that it is
+  correct.

--- a/specs/claude-context/test-spec.md
+++ b/specs/claude-context/test-spec.md
@@ -7,7 +7,7 @@ fresh-session smoke test plus structural spot checks against the requirements.
 
 ### Auto-load
 
-- A fresh Claude session launched with `cwd = /Users/inkatze/dev/dotfiles` shows the
+- A fresh Claude session launched with cwd at the dotfiles repo root shows the
   new `CLAUDE.md` in its loaded context. The system reminder at session start cites
   the file path.
 - Sessions launched with cwd outside the dotfiles repo do **not** load the file
@@ -46,9 +46,10 @@ not meaningful while this spec is in Wave C / plan-only state.
 
 ### Memory hygiene
 
-- No new file is created under
-  `~/.claude/projects/-Users-inkatze-dev-dotfiles/memory/` as part of this work.
-- The existing `project_improvement_plan.md` memory entry is unchanged.
+- No new file is created in the Claude per-project memory directory for this repo
+  as part of this work.
+- The existing `project_improvement_plan.md` memory entry in that directory is
+  unchanged.
 
 ## Out of scope
 

--- a/specs/claude-context/test-spec.md
+++ b/specs/claude-context/test-spec.md
@@ -25,6 +25,9 @@ fresh-session smoke test plus structural spot checks against the requirements.
 
 ### Structural spot checks
 
+These checks run at implementation time, against the actual `CLAUDE.md`. They are
+not meaningful while this spec is in Wave C / plan-only state.
+
 - File length is ≤ 120 lines.
 - No section duplicates content already in `~/.claude/CLAUDE.md` (Fish, mise,
   conventional commits, no-Claude-footer, GPG signing, explicit-remote-on-push).


### PR DESCRIPTION
## Summary
- New `specs/claude-context/` spec (design, requirements, tasks, test-spec) for introducing a tracked `CLAUDE.md` at the dotfiles repo root.
- Plan-only (Wave C); no `CLAUDE.md` written yet. Captures the reframe from "project memory" to repo-root CLAUDE.md, the three-part scope gate, and the soft dependency on improvement-plan #8.

## Test plan
- [ ] Spec is internally consistent across the four files
- [ ] No external/uncommitted file paths referenced