### PR TITLE
docs(spec): add metrics baseline spec (metrics-baseline)

### DIFF
--- a/specs/metrics-baseline/design.md
+++ b/specs/metrics-baseline/design.md
@@ -37,9 +37,10 @@ overwriting an earlier one. This preserves the trajectory.
 
 ## Schema, not just numbers
 
-The first snapshot defines a schema by example. Every subsequent snapshot must
-fill in the same fields with the same definitions, even if a number is zero,
-so that diffs are meaningful. The schema covers: corpus scope, tool-call
+`specs/metrics-baseline/snapshots/SCHEMA.md` defines the snapshot schema.
+The first snapshot is the first instance of that schema, and every snapshot
+must fill in the same fields with the same definitions, even if a number is
+zero, so that diffs are meaningful. The schema covers: corpus scope, tool-call
 volumes (main vs subagent split), top tools, friction tallies by category,
 underused features, slash command usage, interaction style indicators.
 
@@ -226,7 +227,8 @@ or any other improvement.
   diffable and survive memory pruning.
 - **Append-only snapshots, one per re-measurement.** Preserves trajectory and
   prevents accidental loss of historical data.
-- **Schema defined by the first snapshot, fixed thereafter.** Comparability
+- **Schema defined by `specs/metrics-baseline/snapshots/SCHEMA.md`, fixed
+  thereafter unless explicitly changed/versioned there.** Comparability
   requires that every future snapshot fill in the same fields with the same
   definitions.
 - **Main-thread vs subagent split is mandatory for every volume metric.**

--- a/specs/metrics-baseline/design.md
+++ b/specs/metrics-baseline/design.md
@@ -25,10 +25,12 @@ against fuzzy recollections.
 
 ## Mechanism: tracked snapshot files, not memory
 
-Snapshots live as markdown files under `specs/metrics-baseline/snapshots/`,
-named `baseline-YYYY-MM.md`. They are tracked in git so they survive memory
-pruning and are easy to diff. Memory entries remain the prose / narrative form;
-the snapshot is the structured, comparable form.
+Snapshots are committed under `specs/metrics-baseline/snapshots/` as encrypted
+`baseline-YYYY-MM.md.age` files. Only the encrypted `.age` artifact is tracked
+in git so snapshots survive memory pruning without committing plaintext.
+Plaintext markdown may exist only as local working material and must never be
+committed. Memory entries remain the prose / narrative form; the encrypted
+snapshot is the structured, comparable form.
 
 Snapshots are append-only: each re-measurement adds a new file rather than
 overwriting an earlier one. This preserves the trajectory.

--- a/specs/metrics-baseline/design.md
+++ b/specs/metrics-baseline/design.md
@@ -1,0 +1,271 @@
+# Claude Code Usage Metrics Baseline Design Decisions
+
+Decisions specific to capturing a durable baseline of current Claude Code usage
+metrics so that the improvements in `project_improvement_plan` (memory) can be
+measured against a fixed reference point after they ship.
+
+## Status
+
+- **Wave:** 0 (prerequisite). This spec must produce its first snapshot before
+  any improvement-plan item that is expected to move metrics is implemented.
+  Items already shipped (e.g., the AGENTS.md → CLAUDE.md rename in tecpan) are
+  acknowledged as pre-baseline and recorded as such in the snapshot's
+  methodology section.
+- **Decisions resolved:** 2026-04-08.
+
+## Context
+
+The improvement plan currently lives as prose in memory and was driven by an
+ad-hoc analysis of ~463 conversations across two machines. The friction
+numbers (~650 wasted calls/month, 52% subagent tool-call share, etc.) exist
+only as memory entries. Memory is point-in-time and not structured for diffing.
+Without a tracked baseline, any future "did this help?" question becomes
+unanswerable except by re-running the analysis from scratch and comparing
+against fuzzy recollections.
+
+## Mechanism: tracked snapshot files, not memory
+
+Snapshots live as markdown files under `specs/metrics-baseline/snapshots/`,
+named `baseline-YYYY-MM.md`. They are tracked in git so they survive memory
+pruning and are easy to diff. Memory entries remain the prose / narrative form;
+the snapshot is the structured, comparable form.
+
+Snapshots are append-only: each re-measurement adds a new file rather than
+overwriting an earlier one. This preserves the trajectory.
+
+## Schema, not just numbers
+
+The first snapshot defines a schema by example. Every subsequent snapshot must
+fill in the same fields with the same definitions, even if a number is zero,
+so that diffs are meaningful. The schema covers: corpus scope, tool-call
+volumes (main vs subagent split), top tools, friction tallies by category,
+underused features, slash command usage, interaction style indicators.
+
+## Dimensions are first-class, not aggregates
+
+Every volume and friction metric is reported along three dimensions:
+per-project, per-machine (personal vs work), and main-thread vs subagent.
+A global aggregate is not enough. If tecpan's friction drops by 200 wasted
+calls and paycalc's stays flat, we need to *see* that — otherwise the
+improvement plan can't attribute deltas to specific changes, and we're back
+to recollection-based "did this help?"
+
+This applies to every required metric in `requirements.md`, including
+ones where the breakdown looks redundant at snapshot time. Comparability
+across future snapshots requires that the dimensions be filled in
+consistently from the start.
+
+## Metric coverage rationale
+
+The required metrics map directly onto the improvement-plan items they need
+to evaluate:
+
+- **Per-tool error rate** normalizes friction against volume so a drop in
+  errors cannot be confused with a drop in usage.
+- **Permission prompts (approve/deny, per tool)** is the measurement target
+  for items #3 (deny rules) and #4 (permission pruning). Without this,
+  those items have no observable effect.
+- **Hook failure breakdown by hook name** is the target for item #2
+  (PostToolUse auto-format hook). A generic "pre-commit failures" tally
+  cannot show which specific hook stopped firing.
+- **Edit `old_string` mismatch rate** is the single largest friction
+  category in the existing memory analysis and deserves its own line.
+- **Slash command success rate** (not just count) is the target for item
+  #6 (fix `/copilot-review` GraphQL errors). Counting invocations alone
+  cannot show whether they completed.
+- **Hot-file re-reads** is the signal that drove the Wave B reframing of
+  item #11 (claude-context). It is the most direct measure of "did
+  repo-scoped CLAUDE.md context reduce redundant exploration."
+- **Conversation outcomes and tool-calls-per-shipped-commit** is the
+  closest objective proxy for end-to-end efficiency available from JSONL
+  alone.
+- **Stuck-loop sessions** captures the friction signal that hurts most
+  subjectively but is invisible in raw wasted-call totals.
+- **Subagent type breakdown** lets us evaluate Plan mode underuse and the
+  superpowers / Explore subagent shifts independently of total subagent
+  volume.
+- **MCP tool usage** lets integrations that fail to earn their keep
+  surface naturally, without having to instrument them individually.
+
+Marginal-but-cheap metrics (time-of-day, file-type breakdown, TodoWrite
+usage, token/cost) are listed as optional because they add insight at near-
+zero cost but should not block the snapshot if they prove fiddly to compute.
+
+## Explicitly *not* measured
+
+- **Latency.** Out of scope per requirements; noisy and machine-dependent.
+- **Context-window or compaction events.** Too noisy at this size; would
+  generate signal where there is none.
+- **Subjective success rate.** Not objectively recoverable from JSONL.
+  Conversation-outcome heuristics (commit / push / PR / nothing) are the
+  closest honest proxy and are required instead.
+
+## Encryption: age with SSH-key recipients
+
+The repo is public. Snapshot data (per-project conversation counts,
+friction tallies, hot-file lists, MCP usage) should not be world-readable.
+Schema and methodology, by contrast, are intentionally public so the
+approach is reviewable.
+
+The chosen mechanism is **age** with SSH public keys as recipients, with
+exactly these properties:
+
+- **Asymmetric, public-recipient.** The recipient public key is committed
+  in plaintext as `recipients.txt`. Anyone — you on either machine, Claude
+  in any session, even a fresh clone — can encrypt a new snapshot. Only
+  the holder of the matching SSH private key can decrypt. Writes are
+  unprivileged, reads are privileged. This is exactly the asymmetry the
+  workflow needs.
+- **No new key material.** age accepts SSH keys directly:
+  `age -R recipients.txt baseline-YYYY-MM.md > baseline-YYYY-MM.md.age`
+  to encrypt, `age -i ~/.ssh/<key> -d baseline-YYYY-MM.md.age` to
+  decrypt. Both machines already have the SSH key; no new secret to
+  manage or sync.
+- **File-level, not repo-level.** Only the snapshot data files are
+  encrypted (`baseline-*.md.age`). The schema, the four spec files, the
+  recipients file, and any helper script remain plaintext and reviewable
+  in the public repo. The split between "structure is public, data is
+  private" is the whole point.
+- **Opaque on GitHub.** The `.age` blob renders as binary in the web UI;
+  no accidental leakage via search indexers or web previews.
+
+Alternatives considered and rejected:
+
+- **git-crypt.** Symmetric key, requires `git-crypt unlock` per clone, and
+  loses the asymmetric "anyone can write, only you can read" property.
+  Also awkward to share the unlock key safely between two machines.
+- **sops.** Designed for structured configs (YAML/JSON); overkill for
+  markdown and adds a wrapper around the prose.
+- **Plain GPG.** Already in use for commit signing, but age is simpler,
+  has fewer footguns, and the SSH-key path means zero new key material.
+  GPG would also require deciding on key servers, expiration, etc.
+
+A pre-commit guard rejects any staged unencrypted `baseline-*.md` file
+under `snapshots/`. This prevents the obvious foot-gun (forgetting to
+encrypt and committing the plaintext file) at the only point where it
+matters.
+
+## Subagent split is first-class
+
+`project_subagent_volume` documents that the first analysis pass undercounted
+tool calls by 52% because it ignored `<session-id>/subagents/` JSONL files.
+The schema treats main-thread vs subagent as a required split for every
+volume metric. Folding them silently is a regression and is not allowed.
+
+## Methodology recorded inline
+
+Each snapshot embeds its own methodology section: which roots were walked,
+which subdirectories were included, the exact date window, any known caveats.
+This is what makes a future re-run reproducible without having to reconstruct
+how the previous run worked.
+
+## Pre-baseline acknowledgements
+
+Improvements that have already shipped before the baseline is taken
+(AGENTS.md → CLAUDE.md rename in tecpan, terraform bump, etc.) are listed in
+the snapshot's methodology section as "pre-baseline state." Their effects, if
+any, are baked into the baseline numbers and cannot be measured retroactively.
+This is a known limitation, not a flaw to fix.
+
+## Automation: deferred
+
+The first snapshot may be produced by a one-off script or even by hand.
+Building a reusable metrics tool is explicitly out of scope for this spec.
+What matters is that the schema and the artifact exist; tooling can come
+later if re-measurement frequency justifies it.
+
+## Snapshot is data; reports are regeneratable views
+
+The snapshot is the durable, structured *data*. HTML reports (the
+existing `personal-usage-report.html` and `usage-report.html` on the
+user's Desktop) are *views* over that data, produced by a renderer
+script that reads either the decrypted snapshot or the live JSONL
+corpus. They are not committed to the repo and not part of this spec's
+deliverables.
+
+The schema is intentionally designed so that **two report variants** can
+be regenerated from the same snapshot:
+
+- A **full-data variant** with content-derived fields (top bash command
+  patterns, top user opener verbs, repo paths, project names) for
+  private use.
+- An **anonymous / shareable variant** that omits or redacts the same
+  fields and renders only the structural sections, suitable for sharing
+  without leaking private context.
+
+The fields needed for the full variant — top bash patterns, top opener
+verbs, daily conversation counts, per-project and per-machine breakdowns
+— are listed in `requirements.md`. The anonymous variant is a strict
+subset rendered by the same renderer; no separate schema is required.
+
+Top bash command patterns are content-derived and can leak repo paths
+and command-line context. They are only acceptable in the snapshot
+because the snapshot is encrypted at rest. If encryption is ever
+disabled, the bash-pattern field must be removed from the schema rather
+than emitted in plaintext. This constraint is recorded in
+`requirements.md` and is non-negotiable.
+
+The renderer itself is deferred (see "Automation: deferred"). What this
+spec locks in is that the snapshot contains the data both report
+variants need.
+
+## Relationship to claude-context spec
+
+This spec is a sibling, not a parent or child, of `specs/claude-context/`.
+The claude-context work (repo-root `CLAUDE.md`) is one of the improvements
+that the baseline will eventually be used to evaluate. Producing the baseline
+first is a prerequisite for being able to attribute any future delta to that
+or any other improvement.
+
+## Decision log
+
+- **Tracked file under `specs/metrics-baseline/snapshots/`, not a memory
+  entry.** Memory is unstructured and point-in-time; baselines need to be
+  diffable and survive memory pruning.
+- **Append-only snapshots, one per re-measurement.** Preserves trajectory and
+  prevents accidental loss of historical data.
+- **Schema defined by the first snapshot, fixed thereafter.** Comparability
+  requires that every future snapshot fill in the same fields with the same
+  definitions.
+- **Main-thread vs subagent split is mandatory for every volume metric.**
+  Documented undercount risk from `project_subagent_volume` makes this
+  non-negotiable.
+- **Per-project and per-machine dimensions are also mandatory.** Aggregates
+  alone make deltas un-attributable to specific improvements or specific
+  repos.
+- **Required metrics map onto improvement-plan items.** Per-tool error rate,
+  permission prompts (approve/deny per tool), hook failures by hook name,
+  Edit `old_string` mismatch rate, slash command success rate, hot-file
+  re-reads, conversation outcomes, stuck-loop sessions, and subagent type
+  breakdown each exist to make a specific plan item measurable. Marginal
+  signals (time-of-day, file-type, TodoWrite, token/cost) are optional.
+- **Latency, context-window/compaction events, and subjective success rate
+  are explicitly not measured.** Out of scope, too noisy, or not recoverable
+  from JSONL.
+- **Encryption: age with SSH-key recipients, file-level.** Only snapshot
+  data files are encrypted (`baseline-*.md.age`); schema and the four spec
+  files stay plaintext. The recipient public key is committed in
+  `recipients.txt`. Anyone can encrypt a new snapshot; only the SSH
+  private-key holder can decrypt. No new key material to manage.
+- **Pre-commit guard rejects staged plaintext `baseline-*.md` files** under
+  `snapshots/`. Cheap, blocks the only realistic foot-gun.
+- **git-crypt, sops, and plain GPG considered and rejected.** git-crypt is
+  symmetric and loses the asymmetric write-vs-read property; sops is
+  overkill for markdown; plain GPG works but is more ceremony than age and
+  brings no advantage here.
+- **Methodology recorded inline in each snapshot.** Reproducibility without
+  external context.
+- **Pre-baseline shipped improvements are acknowledged, not retro-measured.**
+  Honest limitation; do not pretend otherwise.
+- **Snapshot is data; HTML reports are regeneratable views.** Two report
+  variants (full-data and anonymous) are reproducible from the same
+  snapshot by the same deferred renderer; no separate schema is needed.
+- **Top bash command patterns and top opener verbs are optional, encrypted-only
+  metrics.** Worth capturing for full-data report regeneration; bash patterns
+  must be removed from the schema rather than emitted in plaintext if
+  encryption is ever disabled.
+- **Daily conversation counts are required in corpus scope.** Cheap and
+  necessary for reproducing the "conversations per day" sparkline both
+  report variants render.
+- **No automation in this spec.** Schema and first artifact are the deliverable;
+  tooling is deferred until re-measurement frequency justifies the cost.

--- a/specs/metrics-baseline/requirements.md
+++ b/specs/metrics-baseline/requirements.md
@@ -160,7 +160,8 @@ public so the approach is reviewable.
 - Re-measurement shall be performed on demand. The trigger is an explicit
   request to capture a follow-up baseline so current metrics can be compared
   against the stored baseline. Follow-up snapshots shall be stored as
-  additive artifacts at `snapshots/baseline-YYYY-MM.md.age` using the same
+  additive artifacts at
+  `specs/metrics-baseline/snapshots/baseline-YYYY-MM.md.age` using the same
   schema.
 - Follow-up snapshots shall not overwrite earlier ones. Each is additive.
 - Each follow-up snapshot shall fill in every field defined by the schema,

--- a/specs/metrics-baseline/requirements.md
+++ b/specs/metrics-baseline/requirements.md
@@ -9,11 +9,15 @@
 
 ## Snapshot artifact
 
-- The system shall produce a tracked file at
-  `specs/metrics-baseline/snapshots/baseline-YYYY-MM.md` containing the metrics
-  defined below. The initial snapshot is `baseline-2026-04.md`.
-- The snapshot shall be tracked in git, not stored only in memory, so that
-  future re-runs can diff against it without depending on memory persistence.
+- The system shall produce a tracked encrypted file at
+  `specs/metrics-baseline/snapshots/baseline-YYYY-MM.md.age` containing the
+  metrics defined below. The initial snapshot is
+  `baseline-2026-04.md.age`.
+- The encrypted snapshot artifact shall be tracked in git, not stored only in
+  memory, so that future re-runs can diff against it without depending on
+  memory persistence.
+- Any plaintext `baseline-YYYY-MM.md` may exist only transiently during local
+  generation, review, or encryption, and shall not be committed to git.
 - The snapshot shall be self-contained: it does not require access to the
   source JSONL corpus to be interpreted later.
 
@@ -147,9 +151,11 @@ public so the approach is reviewable.
 
 ## Re-measurement protocol
 
-- The spec shall define the cadence and trigger for re-measurement (e.g., 30
-  days after the first improvement lands, or on demand) and the location for
-  follow-up snapshots (`snapshots/baseline-YYYY-MM.md.age`, same schema).
+- Re-measurement shall be performed on demand. The trigger is an explicit
+  request to capture a follow-up baseline so current metrics can be compared
+  against the stored baseline. Follow-up snapshots shall be stored as
+  additive artifacts at `snapshots/baseline-YYYY-MM.md.age` using the same
+  schema.
 - Follow-up snapshots shall not overwrite earlier ones. Each is additive.
 - Each follow-up snapshot shall fill in every field defined by the schema,
   even if the value is zero, so that diffs across snapshots remain

--- a/specs/metrics-baseline/requirements.md
+++ b/specs/metrics-baseline/requirements.md
@@ -1,0 +1,166 @@
+# Claude Code Usage Metrics Baseline Requirements
+
+## Purpose
+
+- The system shall capture a structured baseline snapshot of current Claude Code
+  usage metrics so that the improvements tracked in
+  `project_improvement_plan` (memory) can be re-measured later against the
+  same methodology and the deltas attributed to specific changes.
+
+## Snapshot artifact
+
+- The system shall produce a tracked file at
+  `specs/metrics-baseline/snapshots/baseline-YYYY-MM.md` containing the metrics
+  defined below. The initial snapshot is `baseline-2026-04.md`.
+- The snapshot shall be tracked in git, not stored only in memory, so that
+  future re-runs can diff against it without depending on memory persistence.
+- The snapshot shall be self-contained: it does not require access to the
+  source JSONL corpus to be interpreted later.
+
+## Required dimensions
+
+Every volume and friction metric below shall be reportable along **all** of:
+
+- **Per project** (tecpan, paycalc-services, dotfiles, etc.), not only as a
+  global aggregate.
+- **Per machine** (personal vs work), as a first-class split.
+- **Main-thread vs subagent.** The 52% subagent share documented in
+  `project_subagent_volume` must be preserved as a first-class split, not
+  folded silently into a single number.
+
+A metric reported only as a global aggregate is incomplete.
+
+## Required metrics
+
+The snapshot shall record, at minimum:
+
+- **Corpus scope.** Date range, machines included, per-project conversation
+  counts, total conversation count, dominant model, and daily conversation
+  counts within the window (one number per day).
+- **Tool-call volumes.** Total tool calls under the dimensions above.
+- **Top tools by volume**, separately for main-thread and subagent.
+- **Per-tool error rate.** Errors / calls for each tool, normalized so a
+  drop in errors cannot be confused with a drop in usage.
+- **Friction tallies.** Wasted-call counts per category, including at minimum:
+  Edit `old_string` mismatches (called out as its own line, not folded into a
+  generic "Edit mismatches"), pre-commit / push hook failures broken down by
+  hook name, file path mistakes, user rejections, GH GraphQL errors, and any
+  other categories surfaced. Plus the overall wasted-call total and its
+  share of all tool usage.
+- **Permission prompts.** Count of permission prompts triggered, split by
+  approve vs deny outcome, and split by tool. This is the measurement target
+  for improvement-plan items #3 (deny rules) and #4 (permission pruning).
+- **Stuck-loop sessions.** Count of sessions containing ≥3 consecutive
+  same-tool calls where each errored.
+- **Underused features.** Agent/subagent share, Plan mode invocation count,
+  subagent invocations broken down by subagent type (Explore, Plan,
+  general-purpose, custom), memory file inventory at snapshot time.
+- **Slash command usage.** Counts for the top slash commands (review, commit,
+  etc.) **and** their success rate (did the invocation reach its terminal
+  action — commit landed, PR created, threads resolved — or bail mid-flow).
+- **MCP tool usage.** Counts per MCP server (Gmail, GCal, etc.), so
+  integrations that fail to earn their keep are visible.
+- **Hot-file re-reads.** Top N most-re-read files per project per session.
+  This is the signal that drove the Wave B reframing of item #11; tracking
+  it lets us see whether project-scoped CLAUDE.md files reduce re-reads.
+- **Conversation outcomes.** For each session, did it end with a commit /
+  push / PR / nothing? Plus the derived "tool calls per shipped commit"
+  ratio per project.
+- **Interaction style indicators.** Median user turns per conversation,
+  median tool calls per conversation, interrupt rate, tool-rejection rate.
+
+The snapshot **may** also record (cheap to include, useful as secondary
+signals; do not block on these):
+
+- Time-of-day / day-of-week distribution of tool-call volume.
+- File-type breakdown of Edit / Write volume (which languages dominate).
+- TodoWrite / Task tool usage frequency.
+- Token / cost per session, if the JSONL exposes it.
+- **Top N user opener verbs.** First-word frequency from user messages
+  (e.g., "lets" 372, "yes" 214, "fix" 46). Capped at top 20 to keep
+  cardinality bounded. Useful for tracking shifts in interaction style.
+- **Top N bash command patterns.** Frequency of bash invocations, normalized
+  to keep the leading command and notable flags. Useful for spotting
+  repeated workflows that should become slash commands or hooks. **Only
+  permitted while snapshots are encrypted at rest** — these strings can
+  contain repo paths, hostnames, and command-line context. If encryption is
+  ever disabled for snapshots, this metric must be removed from the schema
+  rather than emitted in plaintext.
+
+## Report regeneration
+
+The snapshot shall capture enough data to regenerate both report variants
+the user already produces locally:
+
+- **Full-data report** (e.g., the existing `personal-usage-report.html`),
+  which includes per-project breakdowns, top bash command patterns, top
+  user opener verbs, and other content-derived signals.
+- **Anonymous / shareable report** (e.g., the existing `usage-report.html`
+  variant), which renders the same structural sections — overview,
+  interaction style, use case breakdown, tool usage patterns, friction
+  points — but redacts or omits content-derived fields (bash command
+  strings, repo paths, project names) so it can be shared without leaking
+  private context.
+
+Both variants are produced by the same renderer reading the same snapshot,
+differing only in which fields are included and whether identifiers are
+redacted. The renderer itself is out of scope for this spec; the
+requirement here is that the snapshot contain sufficient fields for both
+variants to be reproducible.
+
+## Methodology section
+
+- The snapshot shall include a "How this was measured" section recording:
+  - Which directories were walked (`~/.claude/projects/` and any remote
+    history root), explicitly noting that `<session-id>/subagents/` JSONL
+    files must be included.
+  - The exact date window used.
+  - Any known caveats or undercounts.
+- The methodology shall be explicit enough that a future re-run can reproduce
+  the same numbers given the same corpus.
+
+## Encryption and storage
+
+This repo is public. Snapshot contents include per-project conversation
+counts, friction tallies, hot-file lists, and other usage data that should
+not be world-readable. Schema and methodology, by contrast, are intentionally
+public so the approach is reviewable.
+
+- The snapshot **data files** shall be stored encrypted at rest in the repo
+  as `specs/metrics-baseline/snapshots/baseline-YYYY-MM.md.age` using the
+  `age` encryption tool.
+- An unencrypted `baseline-YYYY-MM.md` file shall **not** be committed under
+  any circumstances. A pre-commit guard shall reject any staged plaintext
+  `baseline-*.md` file under `specs/metrics-baseline/snapshots/`.
+- Authorized recipients shall be declared in
+  `specs/metrics-baseline/snapshots/recipients.txt` as one or more SSH public
+  keys, committed in plaintext. Anyone (any machine, any Claude session) can
+  encrypt a new snapshot using these recipients; only the holder of the
+  matching SSH private key can decrypt.
+- The schema file (`SCHEMA.md`), the four spec files
+  (`requirements.md`, `design.md`, `tasks.md`, `test-spec.md`), and any
+  helper script shall remain plaintext. They document structure and
+  methodology, not data.
+- The encrypt and decrypt commands (using `age -R recipients.txt` to
+  encrypt and `age -i ~/.ssh/<key> -d` to decrypt) shall be documented in
+  the snapshots directory's `README.md`.
+
+## Re-measurement protocol
+
+- The spec shall define the cadence and trigger for re-measurement (e.g., 30
+  days after the first improvement lands, or on demand) and the location for
+  follow-up snapshots (`snapshots/baseline-YYYY-MM.md.age`, same schema).
+- Follow-up snapshots shall not overwrite earlier ones. Each is additive.
+- Each follow-up snapshot shall fill in every field defined by the schema,
+  even if the value is zero, so that diffs across snapshots remain
+  structurally comparable.
+
+## Out of scope
+
+- Building a fully automated metrics pipeline. The first snapshot may be
+  produced by a one-off script or by hand; only the schema and the artifact
+  are required to be durable.
+- Performance, latency, or context-window measurements of individual sessions.
+- Any change to the existing memory entries. The `project_usage_analysis` and
+  `project_subagent_volume` memories remain untouched; the snapshot is the
+  durable, structured form, memory remains the prose form.

--- a/specs/metrics-baseline/requirements.md
+++ b/specs/metrics-baseline/requirements.md
@@ -38,11 +38,17 @@ A metric reported only as a global aggregate is incomplete.
 
 The snapshot shall record, at minimum:
 
-- **Corpus scope.** Date range, machines included, per-project conversation
-  counts, total conversation count, dominant model, and daily conversation
-  counts within the window (one number per day).
+- **Corpus scope.** Date range, machines included, dominant model, and
+  conversation-count metrics: per-project conversation counts, total
+  conversation count, and daily conversation counts within the window (one
+  number per day). These conversation-count metrics shall also be emitted
+  under the required dimensions above: per project, per machine, and
+  main-thread vs subagent, with subagent conversations counted as
+  subagent-thread conversations for that split rather than folded into
+  main-thread totals. Global aggregates may be included in addition to,
+  not instead of, those breakdowns.
 - **Tool-call volumes.** Total tool calls under the dimensions above.
-- **Top tools by volume**, separately for main-thread and subagent.
+- **Top 10 tools by volume**, separately for main-thread and subagent.
 - **Per-tool error rate.** Errors / calls for each tool, normalized so a
   drop in errors cannot be confused with a drop in usage.
 - **Friction tallies.** Wasted-call counts per category, including at minimum:
@@ -59,12 +65,12 @@ The snapshot shall record, at minimum:
 - **Underused features.** Agent/subagent share, Plan mode invocation count,
   subagent invocations broken down by subagent type (Explore, Plan,
   general-purpose, custom), memory file inventory at snapshot time.
-- **Slash command usage.** Counts for the top slash commands (review, commit,
+- **Slash command usage.** Counts for the top 10 slash commands (review, commit,
   etc.) **and** their success rate (did the invocation reach its terminal
   action — commit landed, PR created, threads resolved — or bail mid-flow).
 - **MCP tool usage.** Counts per MCP server (Gmail, GCal, etc.), so
   integrations that fail to earn their keep are visible.
-- **Hot-file re-reads.** Top N most-re-read files per project per session.
+- **Hot-file re-reads.** Top 20 most-re-read files per project per session.
   This is the signal that drove the Wave B reframing of item #11; tracking
   it lets us see whether project-scoped CLAUDE.md files reduce re-reads.
 - **Conversation outcomes.** For each session, did it end with a commit /

--- a/specs/metrics-baseline/tasks.md
+++ b/specs/metrics-baseline/tasks.md
@@ -27,8 +27,10 @@ Create the snapshots directory with the encryption support files:
   `age -R recipients.txt baseline-YYYY-MM.md > baseline-YYYY-MM.md.age`
   and `age -i ~/.ssh/<key> -d baseline-YYYY-MM.md.age`.
 - A pre-commit guard rejecting any staged plaintext `baseline-*.md` file
-  under `snapshots/`. A gitignore entry is not sufficient: the guard must
-  fail loudly rather than silently drop the file.
+  under `snapshots/`. Implement this as an additional `lefthook.yml`
+  pre-commit command, optionally calling a script under
+  `specs/metrics-baseline/`. A gitignore entry is not sufficient: the
+  guard must fail loudly rather than silently drop the file.
 
 ### 3. Produce the first snapshot (encrypted)
 

--- a/specs/metrics-baseline/tasks.md
+++ b/specs/metrics-baseline/tasks.md
@@ -1,0 +1,93 @@
+# Claude Code Usage Metrics Baseline Implementation Status
+
+## Task order
+
+Tasks are ordered by dependency.
+
+### 1. Define the snapshot schema
+
+Write `specs/metrics-baseline/snapshots/SCHEMA.md` describing the required
+sections, field names, and definitions for any baseline snapshot. Pulls from
+`requirements.md` "Required dimensions" and "Required metrics." The schema
+must specify, for every metric, which dimensions it is broken down along
+(per-project, per-machine, main-thread vs subagent) so that future
+re-measurements diff cleanly.
+
+The schema file is plaintext and committed.
+
+### 2. Set up encryption surface
+
+Create the snapshots directory with the encryption support files:
+
+- `specs/metrics-baseline/snapshots/recipients.txt` — one or more SSH
+  public keys (the user's existing keys on the personal and work machines).
+  Plaintext, committed.
+- `specs/metrics-baseline/snapshots/README.md` — short, plaintext.
+  Documents the encrypt and decrypt commands:
+  `age -R recipients.txt baseline-YYYY-MM.md > baseline-YYYY-MM.md.age`
+  and `age -i ~/.ssh/<key> -d baseline-YYYY-MM.md.age`.
+- A `.gitignore` entry (or pre-commit guard) under `snapshots/` rejecting
+  plaintext `baseline-*.md` files. Implementation choice between gitignore
+  and pre-commit hook is left to the implementer; the pre-commit hook is
+  preferred because it fails loudly rather than silently dropping the file.
+
+### 3. Produce the first snapshot (encrypted)
+
+Walk both `~/.claude/projects/` and any remote history root, including
+`<session-id>/subagents/` JSONL files. Compute every metric defined in the
+schema, broken down along every required dimension, for the same date
+window already covered by `project_usage_analysis` memory
+(Mar 3 – Apr 2, 2026), so the first snapshot anchors to numbers the user
+has already seen.
+
+Write the plaintext result to a temporary location, encrypt it with
+`age -R recipients.txt` to
+`specs/metrics-baseline/snapshots/baseline-2026-04.md.age`, then delete
+the plaintext intermediate. Include the methodology section inline in the
+plaintext before encryption. Acknowledge pre-baseline shipped improvements
+(AGENTS.md → CLAUDE.md rename, terraform bump, etc.) under a "Pre-baseline
+state" subsection.
+
+A throwaway script is fine; it does not need to be committed. If it is
+committed, it lives under `specs/metrics-baseline/scripts/` and is marked
+as non-load-bearing. The script must not write the plaintext snapshot to
+the snapshots directory at any point; it may write only to a temp location
+outside the repo or to stdout piped directly into `age`.
+
+### 4. Verify
+
+Confirm the encrypted file decrypts cleanly with the user's SSH key on at
+least one machine, and that the decrypted contents conform to the schema.
+Confirm `git status` shows only the `.age` file under `snapshots/`, never
+a plaintext `baseline-*.md`.
+
+### 5. Cross-link from the improvement plan
+
+Update the `project_improvement_plan` memory entry with a single line
+pointing at `specs/metrics-baseline/snapshots/baseline-2026-04.md.age` as
+the reference point for measuring future improvements. This is the only
+memory edit this spec performs.
+
+### 6. Commit on a feature branch
+
+Conventional commit, no Claude footer, no co-author, GPG signed.
+Example: `docs(spec): add metrics baseline spec and 2026-04 snapshot`. Push
+and PR happen as part of the implementation workflow, not this task.
+
+## Dependencies
+
+- **Blocks:** any improvement-plan item whose effect should be measured against
+  the baseline. Specifically, the claude-context implementation should not
+  ship until the first snapshot exists, otherwise its effect cannot be
+  attributed.
+- **Blocked by:** nothing.
+
+## Effort
+
+**S** — most of the work is the one-off script to walk the JSONL corpus and
+tally the schema fields. The schema and snapshot prose are short.
+
+## Rollback
+
+`git rm -r specs/metrics-baseline/` and revert the memory cross-link line.
+No other surfaces are touched.

--- a/specs/metrics-baseline/tasks.md
+++ b/specs/metrics-baseline/tasks.md
@@ -26,10 +26,9 @@ Create the snapshots directory with the encryption support files:
   Documents the encrypt and decrypt commands:
   `age -R recipients.txt baseline-YYYY-MM.md > baseline-YYYY-MM.md.age`
   and `age -i ~/.ssh/<key> -d baseline-YYYY-MM.md.age`.
-- A `.gitignore` entry (or pre-commit guard) under `snapshots/` rejecting
-  plaintext `baseline-*.md` files. Implementation choice between gitignore
-  and pre-commit hook is left to the implementer; the pre-commit hook is
-  preferred because it fails loudly rather than silently dropping the file.
+- A pre-commit guard rejecting any staged plaintext `baseline-*.md` file
+  under `snapshots/`. A gitignore entry is not sufficient: the guard must
+  fail loudly rather than silently drop the file.
 
 ### 3. Produce the first snapshot (encrypted)
 

--- a/specs/metrics-baseline/test-spec.md
+++ b/specs/metrics-baseline/test-spec.md
@@ -1,0 +1,79 @@
+# Claude Code Usage Metrics Baseline Test Specification
+
+## What to verify
+
+There is no automated test surface. Verification is by structural checks
+against the schema and a sanity pass against the existing memory numbers.
+
+### Schema conformance
+
+- The decrypted `snapshots/baseline-2026-04.md` contains every section
+  defined in `snapshots/SCHEMA.md`. Missing sections are a failure even if
+  the underlying number is zero.
+- Every volume and friction metric is reported along all three required
+  dimensions: per-project, per-machine (personal vs work), and main-thread
+  vs subagent. A metric reported only as a global aggregate is a failure.
+- All required metrics from `requirements.md` are present, including
+  per-tool error rate, permission prompts (approve/deny per tool),
+  hook failures broken down by hook name, Edit `old_string` mismatch rate,
+  slash command success rate, hot-file re-reads, conversation outcomes,
+  stuck-loop sessions, subagent type breakdown, and MCP usage.
+- The methodology section names every directory walked, including
+  `<session-id>/subagents/`, and the exact date window.
+
+### Encryption hygiene
+
+- Only `baseline-*.md.age` files exist under `snapshots/`. No plaintext
+  `baseline-*.md` is committed, staged, or present on disk in the
+  snapshots directory after the snapshot task completes.
+- The pre-commit guard (or gitignore) rejects a deliberate test commit
+  attempting to stage a plaintext `baseline-*.md` file.
+- `recipients.txt` exists in plaintext, contains at least one valid SSH
+  public key, and is committed.
+- The encrypted snapshot decrypts successfully with the user's SSH private
+  key (`age -i ~/.ssh/<key> -d`) on at least one of the user's machines,
+  and the decrypted contents pass the schema conformance checks above.
+- `SCHEMA.md`, the four spec files, `recipients.txt`, `README.md`, and any
+  helper script remain plaintext and reviewable.
+
+### Sanity against memory
+
+The first snapshot's headline numbers must be in the same ballpark as
+`project_usage_analysis` and `project_subagent_volume` memory entries:
+
+- Total conversations ≈ 463 for Mar 3 – Apr 2, 2026.
+- Subagent share of tool calls ≈ 52%.
+- Wasted-call total ≈ 650, ≈ 4% of all tool usage.
+- Top subagent tools roughly match: Read, Bash, Grep, Glob.
+
+Order-of-magnitude divergences require investigation before the snapshot is
+committed; small drift is expected because the memory numbers were rounded.
+
+### Pre-baseline acknowledgement present
+
+The snapshot's methodology section explicitly lists improvements that
+shipped before the baseline window closed (AGENTS.md → CLAUDE.md rename,
+terraform bump, any others). Listing zero is acceptable only if zero is true.
+
+### Diff hygiene
+
+The implementation commit touches only files under `specs/metrics-baseline/`
+plus the single cross-link line in the `project_improvement_plan` memory
+entry. No stray edits to unrelated config, roles, or other specs.
+
+### Re-measurement readiness
+
+A reader who has never seen the source corpus can, from `SCHEMA.md` and the
+first snapshot's methodology section alone, reproduce the same numbers given
+the same JSONL files. If reproduction requires asking the original author for
+context, the methodology section is incomplete.
+
+## Out of scope
+
+- Building or testing an automated metrics pipeline. The first snapshot may
+  be produced by a throwaway script.
+- Validating the *correctness* of any specific friction category's
+  classification logic. The schema defines categories; classification quality
+  is a separate, later concern.
+- Measuring the effect of improvements. That is what future snapshots are
+  for, not this one.

--- a/specs/metrics-baseline/test-spec.md
+++ b/specs/metrics-baseline/test-spec.md
@@ -7,9 +7,10 @@ against the schema and a sanity pass against the existing memory numbers.
 
 ### Schema conformance
 
-- The decrypted `snapshots/baseline-2026-04.md` contains every section
-  defined in `snapshots/SCHEMA.md`. Missing sections are a failure even if
-  the underlying number is zero.
+- The decrypted contents of `snapshots/baseline-2026-04.md.age` (for
+  example, decrypted to stdout or a temporary location outside
+  `snapshots/`) contain every section defined in `snapshots/SCHEMA.md`.
+  Missing sections are a failure even if the underlying number is zero.
 - Every volume and friction metric is reported along all three required
   dimensions: per-project, per-machine (personal vs work), and main-thread
   vs subagent. A metric reported only as a global aggregate is a failure.
@@ -26,8 +27,8 @@ against the schema and a sanity pass against the existing memory numbers.
 - Only `baseline-*.md.age` files exist under `snapshots/`. No plaintext
   `baseline-*.md` is committed, staged, or present on disk in the
   snapshots directory after the snapshot task completes.
-- The pre-commit guard (or gitignore) rejects a deliberate test commit
-  attempting to stage a plaintext `baseline-*.md` file.
+- The pre-commit guard rejects a deliberate test commit attempting to
+  stage a plaintext `baseline-*.md` file.
 - `recipients.txt` exists in plaintext, contains at least one valid SSH
   public key, and is committed.
 - The encrypted snapshot decrypts successfully with the user's SSH private
@@ -57,9 +58,11 @@ terraform bump, any others). Listing zero is acceptable only if zero is true.
 
 ### Diff hygiene
 
-The implementation commit touches only files under `specs/metrics-baseline/`
+The implementation commit touches only files under `specs/metrics-baseline/`,
 plus the single cross-link line in the `project_improvement_plan` memory
-entry. No stray edits to unrelated config, roles, or other specs.
+entry, plus any minimal repo-level hook or ignore configuration needed
+solely to enforce the plaintext `baseline-*.md` guard. No other stray
+edits to unrelated config, roles, or other specs.
 
 ### Re-measurement readiness
 

--- a/specs/metrics-baseline/test-spec.md
+++ b/specs/metrics-baseline/test-spec.md
@@ -7,10 +7,12 @@ against the schema and a sanity pass against the existing memory numbers.
 
 ### Schema conformance
 
-- The decrypted contents of `snapshots/baseline-2026-04.md.age` (for
-  example, decrypted to stdout or a temporary location outside
-  `snapshots/`) contain every section defined in `snapshots/SCHEMA.md`.
-  Missing sections are a failure even if the underlying number is zero.
+- The decrypted contents of
+  `specs/metrics-baseline/snapshots/baseline-2026-04.md.age` (for example,
+  decrypted to stdout or a temporary location outside
+  `specs/metrics-baseline/snapshots/`) contain every section defined in
+  `specs/metrics-baseline/snapshots/SCHEMA.md`. Missing sections are a
+  failure even if the underlying number is zero.
 - Every volume and friction metric is reported along all three required
   dimensions: per-project, per-machine (personal vs work), and main-thread
   vs subagent. A metric reported only as a global aggregate is a failure.
@@ -24,18 +26,21 @@ against the schema and a sanity pass against the existing memory numbers.
 
 ### Encryption hygiene
 
-- Only `baseline-*.md.age` files exist under `snapshots/`. No plaintext
-  `baseline-*.md` is committed, staged, or present on disk in the
-  snapshots directory after the snapshot task completes.
+- Only `baseline-*.md.age` files exist under
+  `specs/metrics-baseline/snapshots/`. No plaintext `baseline-*.md` is
+  committed, staged, or present on disk in the snapshots directory after
+  the snapshot task completes.
 - The pre-commit guard rejects a deliberate test commit attempting to
   stage a plaintext `baseline-*.md` file.
-- `recipients.txt` exists in plaintext, contains at least one valid SSH
-  public key, and is committed.
+- `specs/metrics-baseline/snapshots/recipients.txt` exists in plaintext,
+  contains at least one valid SSH public key, and is committed.
 - The encrypted snapshot decrypts successfully with the user's SSH private
   key (`age -i ~/.ssh/<key> -d`) on at least one of the user's machines,
   and the decrypted contents pass the schema conformance checks above.
-- `SCHEMA.md`, the four spec files, `recipients.txt`, `README.md`, and any
-  helper script remain plaintext and reviewable.
+- `specs/metrics-baseline/snapshots/SCHEMA.md`, the four spec files,
+  `specs/metrics-baseline/snapshots/recipients.txt`,
+  `specs/metrics-baseline/snapshots/README.md`, and any helper script
+  remain plaintext and reviewable.
 
 ### Sanity against memory
 


### PR DESCRIPTION
## Summary

Adds `specs/metrics-baseline/` as a new sibling spec to `specs/claude-context/`. Defines a structured, encrypted-at-rest baseline of Claude Code usage metrics so the items in `project_improvement_plan` (memory) can be re-measured against a fixed reference point and deltas attributed to specific changes.

## What's in the spec

- **Required dimensions:** every volume and friction metric is reported per-project, per-machine (personal vs work), and main-thread vs subagent. Aggregates alone are insufficient.
- **Required metrics:** corpus scope (incl. daily conversation counts), tool-call volumes, top tools, per-tool error rate, friction tallies (with Edit `old_string` mismatches and hook failures broken down by hook name as their own lines), permission prompts (approve/deny per tool), stuck-loop sessions, subagent type breakdown, slash command usage *and success rate*, MCP usage, hot-file re-reads, conversation outcomes, interaction style indicators.
- **Optional metrics:** time-of-day, file-type breakdown, TodoWrite/Task usage, token/cost, top user opener verbs, top bash command patterns (the last is encrypted-only).
- **Encryption:** snapshots stored as `baseline-YYYY-MM.md.age` using `age` with SSH-key recipients in plaintext `recipients.txt`. Schema and spec files stay plaintext. Pre-commit guard rejects staged plaintext `baseline-*.md`.
- **Report regeneration:** schema is designed so both the full-data and anonymous HTML report variants the user already produces locally can be regenerated from the same snapshot by a deferred renderer.

## Why now

This blocks the implementation of `claude-context` and other improvement-plan items whose effects should be measurable. Without a tracked baseline, "did this help?" stays unanswerable.

## Test plan

- [ ] Read `requirements.md` and confirm every dimension and metric is one you actually want measured.
- [ ] Read `design.md` and confirm the encryption choice (age + SSH recipients, file-level) and the deferred-renderer / snapshot-as-data split are correct.
- [ ] Read `tasks.md` and confirm the implementation order (schema → encryption surface → first snapshot → verify → cross-link → commit) matches your intended workflow.
- [ ] Read `test-spec.md` and confirm the verification gates (schema conformance, encryption hygiene, sanity against memory numbers) are sufficient.
- [ ] Confirm the pre-baseline acknowledgement approach (AGENTS.md → CLAUDE.md rename and terraform bump are baked in, not retro-measured) is acceptable.