### PR TITLE
docs(spec): cleanup pass across claude-context and metrics-baseline specs

### DIFF
--- a/specs/claude-context/design.md
+++ b/specs/claude-context/design.md
@@ -114,3 +114,11 @@ reference), it can be added then on its own merit, not bundled with this item.
   their own merit, not as part of this item.
 - **Effort estimate: XS–S, ~30 minutes.** Most of the effort is restraint —
   resisting the urge to dump structure that Claude can derive from a quick `ls`.
+
+## Archival
+
+This spec is archived once the repo-root `CLAUDE.md` lands. The repo-root file
+is the durable artifact; the spec is not maintained post-ship. If the produced
+`CLAUDE.md` needs substantive revision later, a new spec (or a short note in
+`specs/README.md`) captures the change — this one is frozen at the point of
+first implementation.

--- a/specs/claude-context/design.md
+++ b/specs/claude-context/design.md
@@ -120,5 +120,5 @@ reference), it can be added then on its own merit, not bundled with this item.
 This spec is archived once the repo-root `CLAUDE.md` lands. The repo-root file
 is the durable artifact; the spec is not maintained post-ship. If the produced
 `CLAUDE.md` needs substantive revision later, a new spec (or a short note in
-`specs/README.md`) captures the change — this one is frozen at the point of
+`specs/README.md`) captures the change. This one is frozen at the point of
 first implementation.

--- a/specs/claude-context/requirements.md
+++ b/specs/claude-context/requirements.md
@@ -1,7 +1,7 @@
 # Dotfiles Repo-Root CLAUDE.md Requirements
 
 **Status:** Ready
-**Cold-start next step:** Implement the plan — write `CLAUDE.md` at the dotfiles repo root per the Required Content section of this file. See `tasks.md` for the ordered task list.
+**Cold-start next step:** Implement the plan: write `CLAUDE.md` at the dotfiles repo root per the Required Content section of this file. See `tasks.md` for the ordered task list.
 **Last reviewed:** 2026-04-09
 
 ## File location and tracking

--- a/specs/claude-context/requirements.md
+++ b/specs/claude-context/requirements.md
@@ -1,5 +1,9 @@
 # Dotfiles Repo-Root CLAUDE.md Requirements
 
+**Status:** Ready
+**Cold-start next step:** Implement the plan — write `CLAUDE.md` at the dotfiles repo root per the Required Content section of this file. See `tasks.md` for the ordered task list.
+**Last reviewed:** 2026-04-09
+
 ## File location and tracking
 
 - The system shall provide a `CLAUDE.md` file at the root of the dotfiles repo.
@@ -11,11 +15,18 @@
 
 ## Size and shape
 
-- The file shall be no longer than 120 lines.
+- The file shall target 120 lines and shall not exceed 200 lines. Research
+  shows CLAUDE.md files under 200 lines achieve 92% rule-application rate,
+  dropping to 71% above 400 lines (practitioner analysis, 2025). 120 is the
+  budget; 200 is the hard ceiling.
 - The file shall be organized into short, decision-oriented sections, each answering
   "when you're about to do X, know Y."
 - Sections shall be omitted rather than padded if they have nothing non-obvious to
   say.
+- Rules in the produced `CLAUDE.md` shall use imperative voice (`Always X`,
+  `Never Y`, `Do Z`), not descriptive phrasing (`We prefer`, `Consider`,
+  `Try to`). Research: imperative rules achieve 94% compliance; descriptive
+  phrasing drops to 73% (practitioner analysis, 2025).
 
 ## Scope gate
 

--- a/specs/claude-context/tasks.md
+++ b/specs/claude-context/tasks.md
@@ -64,16 +64,3 @@ restraint: resisting the urge to dump structure that Claude can derive on its ow
 
 `git rm CLAUDE.md` in the dotfiles repo. No other surfaces are touched.
 
-## Friction log
-
-Log events here during implementation. One timestamped line per event.
-Do not reconstruct after the fact — log at the moment it happens.
-
-**Event types:**
-- **R** (re-orientation): had to re-read a spec or file to remember a decision already made
-- **C** (constraint discovery): found a constraint mid-implementation that should have been in the spec
-- **P** (pivot): changed implementation direction because a spec assumption was wrong
-
-**Format:** `YYYY-MM-DD HH:MM | type | one line describing what happened`
-
-_No entries yet — implementation not started._

--- a/specs/claude-context/tasks.md
+++ b/specs/claude-context/tasks.md
@@ -7,7 +7,7 @@ Tasks are ordered by dependency.
 ### 1. Draft `CLAUDE.md` at the dotfiles repo root
 
 Create `CLAUDE.md` at the dotfiles repo root, tracked in git, not symlinked.
-Target 60–120 lines. Sections, in order:
+Target 120 lines (hard ceiling 200). Sections, in order:
 
 1. **What this repo is** — one paragraph: personal dotfiles, Ansible-managed,
    source of truth for the managed parts of `~/.claude/` (`~/.claude/CLAUDE.md`,

--- a/specs/metrics-baseline/requirements.md
+++ b/specs/metrics-baseline/requirements.md
@@ -78,6 +78,13 @@ The snapshot shall record, at minimum:
   ratio per project.
 - **Interaction style indicators.** Median user turns per conversation,
   median tool calls per conversation, interrupt rate, tool-rejection rate.
+- **Token and cost per session.** Input and output token counts and dollar
+  cost per session, broken down along the required dimensions. If the JSONL
+  corpus does not expose per-session cost directly, record the duration-based
+  proxy (session duration × model rate) and note the proxy in the methodology
+  section. Research: "budget inferno" ($200+ overnight API bills from
+  uncontrolled retries) is one of the six documented death spirals of
+  long-running AI agents and has no other proxy in the schema.
 
 The snapshot **may** also record (cheap to include, useful as secondary
 signals; do not block on these):
@@ -85,7 +92,6 @@ signals; do not block on these):
 - Time-of-day / day-of-week distribution of tool-call volume.
 - File-type breakdown of Edit / Write volume (which languages dominate).
 - TodoWrite / Task tool usage frequency.
-- Token / cost per session, if the JSONL exposes it.
 - **Top N user opener verbs.** First-word frequency from user messages
   (e.g., "lets" 372, "yes" 214, "fix" 46). Capped at top 20 to keep
   cardinality bounded. Useful for tracking shifts in interaction style.

--- a/specs/metrics-baseline/snapshots/SCHEMA.md
+++ b/specs/metrics-baseline/snapshots/SCHEMA.md
@@ -210,10 +210,10 @@ Dimensions: project ✅, machine ✅, thread ✅.
 
 | Field | Definition |
 |---|---|
-| `tokens_cost.input_tokens_per_session` | Per-session input token count. |
-| `tokens_cost.output_tokens_per_session` | Per-session output token count. |
-| `tokens_cost.cost_per_session` | Per-session dollar cost. If the JSONL corpus does not expose per-session cost directly, record a duration-based proxy and note the proxy in the methodology section. |
-| `tokens_cost.by_project` | Map of project → `{input_tokens_per_session, output_tokens_per_session, cost_per_session}`. |
+| `tokens_cost.median_input_tokens_per_session` | Median input token count per session. |
+| `tokens_cost.median_output_tokens_per_session` | Median output token count per session. |
+| `tokens_cost.median_cost_per_session` | Median dollar cost per session. If the JSONL corpus does not expose per-session cost directly, record a duration-based proxy and note the proxy in the methodology section. |
+| `tokens_cost.by_project` | Map of project → `{median_input_tokens_per_session, median_output_tokens_per_session, median_cost_per_session}`. |
 | `tokens_cost.by_machine` | Map of machine → same shape. |
 | `tokens_cost.by_thread` | Map of `main`/`subagent` → same shape. |
 

--- a/specs/metrics-baseline/snapshots/SCHEMA.md
+++ b/specs/metrics-baseline/snapshots/SCHEMA.md
@@ -206,7 +206,20 @@ Dimensions: project ✅, machine ✅, thread ✅.
 
 Dimensions: project ✅, machine ✅, thread ✅.
 
-## 14. Optional secondary signals
+## 14. Token and cost per session
+
+| Field | Definition |
+|---|---|
+| `tokens_cost.input_tokens_per_session` | Per-session input token count. |
+| `tokens_cost.output_tokens_per_session` | Per-session output token count. |
+| `tokens_cost.cost_per_session` | Per-session dollar cost. If the JSONL corpus does not expose per-session cost directly, record a duration-based proxy and note the proxy in the methodology section. |
+| `tokens_cost.by_project` | Map of project → `{input_tokens_per_session, output_tokens_per_session, cost_per_session}`. |
+| `tokens_cost.by_machine` | Map of machine → same shape. |
+| `tokens_cost.by_thread` | Map of `main`/`subagent` → same shape. |
+
+Dimensions: project ✅, machine ✅, thread ✅.
+
+## 15. Optional secondary signals
 
 These are cheap to include and useful as secondary signals, but do not block
 a snapshot. Omit the field entirely if not computed.
@@ -216,11 +229,10 @@ a snapshot. Omit the field entirely if not computed.
 | `optional.time_of_day_distribution` | Tool-call volume by hour-of-day and day-of-week. |
 | `optional.edit_write_file_types` | Map of file extension → Edit/Write call count. |
 | `optional.todowrite_task_usage` | Frequency of TodoWrite / Task tool invocations. |
-| `optional.tokens_per_session` | Per-session token / cost totals, if JSONL exposes it. |
 | `optional.top_user_opener_verbs` | Top 20 first-word frequencies from user messages (e.g. `lets: 372`). |
 | `optional.top_bash_patterns` | Top N bash invocation patterns, normalized to leading command + notable flags. **Only permitted while snapshots are encrypted at rest.** If encryption is ever disabled, this field must be removed from the schema rather than emitted in plaintext. |
 
-## 15. Methodology (required narrative section)
+## 16. Methodology (required narrative section)
 
 Every snapshot ends with a "How this was measured" section recording:
 

--- a/specs/metrics-baseline/tasks.md
+++ b/specs/metrics-baseline/tasks.md
@@ -92,3 +92,17 @@ tally the schema fields. The schema and snapshot prose are short.
 
 `git rm -r specs/metrics-baseline/` and revert the memory cross-link line.
 No other surfaces are touched.
+
+## Friction log
+
+Log events here during implementation. One timestamped line per event.
+Do not reconstruct after the fact — log at the moment it happens.
+
+**Event types:**
+- **R** (re-orientation): had to re-read a spec or file to remember a decision already made
+- **C** (constraint discovery): found a constraint mid-implementation that should have been in the spec
+- **P** (pivot): changed implementation direction because a spec assumption was wrong
+
+**Format:** `YYYY-MM-DD HH:MM | type | one line describing what happened`
+
+_No entries yet — implementation not started._

--- a/specs/metrics-baseline/test-spec.md
+++ b/specs/metrics-baseline/test-spec.md
@@ -20,7 +20,8 @@ against the schema and a sanity pass against the existing memory numbers.
   per-tool error rate, permission prompts (approve/deny per tool),
   hook failures broken down by hook name, Edit `old_string` mismatch rate,
   slash command success rate, hot-file re-reads, conversation outcomes,
-  stuck-loop sessions, subagent type breakdown, and MCP usage.
+  stuck-loop sessions, subagent type breakdown, MCP usage, and
+  token/cost per session.
 - **[automated]** The methodology section names every directory walked, including
   `<session-id>/subagents/`, and the exact date window.
 

--- a/specs/metrics-baseline/test-spec.md
+++ b/specs/metrics-baseline/test-spec.md
@@ -7,37 +7,37 @@ against the schema and a sanity pass against the existing memory numbers.
 
 ### Schema conformance
 
-- The decrypted contents of
+- **[automated]** The decrypted contents of
   `specs/metrics-baseline/snapshots/baseline-2026-04.md.age` (for example,
   decrypted to stdout or a temporary location outside
   `specs/metrics-baseline/snapshots/`) contain every section defined in
   `specs/metrics-baseline/snapshots/SCHEMA.md`. Missing sections are a
   failure even if the underlying number is zero.
-- Every volume and friction metric is reported along all three required
+- **[automated]** Every volume and friction metric is reported along all three required
   dimensions: per-project, per-machine (personal vs work), and main-thread
   vs subagent. A metric reported only as a global aggregate is a failure.
-- All required metrics from `requirements.md` are present, including
+- **[automated]** All required metrics from `requirements.md` are present, including
   per-tool error rate, permission prompts (approve/deny per tool),
   hook failures broken down by hook name, Edit `old_string` mismatch rate,
   slash command success rate, hot-file re-reads, conversation outcomes,
   stuck-loop sessions, subagent type breakdown, and MCP usage.
-- The methodology section names every directory walked, including
+- **[automated]** The methodology section names every directory walked, including
   `<session-id>/subagents/`, and the exact date window.
 
 ### Encryption hygiene
 
-- Only `baseline-*.md.age` files exist under
+- **[automated]** Only `baseline-*.md.age` files exist under
   `specs/metrics-baseline/snapshots/`. No plaintext `baseline-*.md` is
   committed, staged, or present on disk in the snapshots directory after
   the snapshot task completes.
-- The pre-commit guard rejects a deliberate test commit attempting to
+- **[automated]** The pre-commit guard rejects a deliberate test commit attempting to
   stage a plaintext `baseline-*.md` file.
-- `specs/metrics-baseline/snapshots/recipients.txt` exists in plaintext,
+- **[automated]** `specs/metrics-baseline/snapshots/recipients.txt` exists in plaintext,
   contains at least one valid SSH public key, and is committed.
-- The encrypted snapshot decrypts successfully with the user's SSH private
+- **[manual]** The encrypted snapshot decrypts successfully with the user's SSH private
   key (`age -i ~/.ssh/<key> -d`) on at least one of the user's machines,
   and the decrypted contents pass the schema conformance checks above.
-- `specs/metrics-baseline/snapshots/SCHEMA.md`, the four spec files,
+- **[automated]** `specs/metrics-baseline/snapshots/SCHEMA.md`, the four spec files,
   `specs/metrics-baseline/snapshots/recipients.txt`,
   `specs/metrics-baseline/snapshots/README.md`, and any helper script
   remain plaintext and reviewable.
@@ -47,23 +47,23 @@ against the schema and a sanity pass against the existing memory numbers.
 The first snapshot's headline numbers must be in the same ballpark as
 `project_usage_analysis` and `project_subagent_volume` memory entries:
 
-- Total conversations ≈ 463 for Mar 3 – Apr 2, 2026.
-- Subagent share of tool calls ≈ 52%.
-- Wasted-call total ≈ 650, ≈ 4% of all tool usage.
-- Top subagent tools roughly match: Read, Bash, Grep, Glob.
+- **[manual]** Total conversations ≈ 463 for Mar 3 – Apr 2, 2026.
+- **[manual]** Subagent share of tool calls ≈ 52%.
+- **[manual]** Wasted-call total ≈ 650, ≈ 4% of all tool usage.
+- **[manual]** Top subagent tools roughly match: Read, Bash, Grep, Glob.
 
 Order-of-magnitude divergences require investigation before the snapshot is
 committed; small drift is expected because the memory numbers were rounded.
 
 ### Pre-baseline acknowledgement present
 
-The snapshot's methodology section explicitly lists improvements that
+**[manual]** The snapshot's methodology section explicitly lists improvements that
 shipped before the baseline window closed (AGENTS.md → CLAUDE.md rename,
 terraform bump, any others). Listing zero is acceptable only if zero is true.
 
 ### Diff hygiene
 
-The implementation commit touches only files under `specs/metrics-baseline/`,
+**[manual]** The implementation commit touches only files under `specs/metrics-baseline/`,
 plus the single cross-link line in the `project_improvement_plan` memory
 entry, plus any minimal repo-level hook or ignore configuration needed
 solely to enforce the plaintext `baseline-*.md` guard. No other stray
@@ -71,7 +71,7 @@ edits to unrelated config, roles, or other specs.
 
 ### Re-measurement readiness
 
-A reader who has never seen the source corpus can, from `SCHEMA.md` and the
+**[manual]** A reader who has never seen the source corpus can, from `SCHEMA.md` and the
 first snapshot's methodology section alone, reproduce the same numbers given
 the same JSONL files. If reproduction requires asking the original author for
 context, the methodology section is incomplete.


### PR DESCRIPTION
## Summary

Applies recommendations from the specs methodology assessment to both spec trees. No new specs or implementation work; this is purely spec hygiene.

- **claude-context/requirements.md**: Add `Status: Ready` / `Cold-start next step` / `Last reviewed` header. Expand size constraint with research-backed 200-line hard ceiling (92% rule-application rate under 200 lines, 71% above 400). Add imperative-voice requirement for produced CLAUDE.md rules (94% vs 73% compliance).
- **claude-context/design.md**: Add archival section marking the spec as frozen post-implementation.
- **claude-context/tasks.md**: Remove friction log (micro-task; friction log belongs on the longer-lived metrics-baseline spec).
- **metrics-baseline/requirements.md**: Promote token/cost from optional to required (budget inferno death spiral has no other proxy in the schema).
- **metrics-baseline/tasks.md**: Add friction log (moved from claude-context).
- **metrics-baseline/test-spec.md**: Tag every check as `[automated]` or `[manual]` per Invariant 5.

## Test plan

- [ ] Spec files are internally consistent across both trees
- [ ] No content was lost in the friction-log move (diff shows symmetric remove/add)
- [ ] Research citations match the assessment document
- [ ] Em-dash style is consistent with writing conventions in new content