### PR TITLE
fix(tnotify): write to client TTY and survive PTY destruction

### DIFF
--- a/roles/fish/files/fish/config.fish
+++ b/roles/fish/files/fish/config.fish
@@ -119,7 +119,7 @@ if status --is-interactive; and set -q TMUX
     set -l _tnotify_pid (cat ~/.cache/tnotify.pid 2>/dev/null)
     if test -z "$_tnotify_pid"; or not kill -0 "$_tnotify_pid" 2>/dev/null
         rm -f ~/.cache/tnotify.pid
-        fish -c "tnotify-watch" &>/dev/null &
+        nohup fish -c "tnotify-watch" &>/dev/null &
         disown
     end
 end

--- a/roles/fish/files/fish/functions/tnotify-watch.fish
+++ b/roles/fish/files/fish/functions/tnotify-watch.fish
@@ -6,7 +6,7 @@ function tnotify-watch -d "Watch for notifications and send via tnotify"
     echo %self > "$pidfile"
 
     # Clean up on exit
-    function _tnotify_cleanup --on-signal INT --on-signal TERM --on-process-exit %self
+    function _tnotify_cleanup --on-signal INT --on-signal TERM --on-signal HUP --on-process-exit %self
         rm -f "$HOME/.cache/tnotify.pid"
         functions -e _tnotify_cleanup
     end

--- a/roles/fish/files/fish/functions/tnotify-watch.fish
+++ b/roles/fish/files/fish/functions/tnotify-watch.fish
@@ -7,7 +7,7 @@ function tnotify-watch -d "Watch for notifications and send via tnotify"
 
     # Clean up on exit
     function _tnotify_cleanup --on-signal INT --on-signal TERM --on-signal HUP --on-process-exit %self
-        rm -f "$HOME/.cache/tnotify.pid"
+        rm -f "$pidfile"
         functions -e _tnotify_cleanup
     end
 

--- a/roles/fish/files/fish/functions/tnotify.fish
+++ b/roles/fish/files/fish/functions/tnotify.fish
@@ -1,9 +1,12 @@
 function tnotify -d "Terminal notification that works in tmux + SSH"
     if set -q TMUX
-        # Wrap for tmux passthrough: double all ESC chars and wrap in DCS
-        set -l esc (printf '\e')
-        set -l code (kitten notify --only-print-escape-code $argv | sed "s/$esc/$esc$esc/g")
-        printf '\ePtmux;%s\e\\' "$code" > /dev/tty
+        # Write raw OSC 99 directly to the tmux client TTY, bypassing
+        # per-pane passthrough routing so the watcher isn't tied to
+        # whichever pane originally spawned it.
+        set -l client_tty (tmux list-clients -F '#{client_tty}' 2>/dev/null | head -1)
+        if test -n "$client_tty"
+            kitten notify --only-print-escape-code $argv > "$client_tty"
+        end
     else
         kitten notify $argv
     end


### PR DESCRIPTION
## Summary
- **tnotify**: Write raw OSC 99 directly to the tmux client TTY (`#{client_tty}`) instead of DCS passthrough to `/dev/tty`, so notification delivery isn't tied to the pane that spawned the watcher
- **tnotify-watch**: Add `HUP` to the signal cleanup handler so the PID file is removed if the watcher receives SIGHUP
- **config.fish**: Start the watcher with `nohup` to survive PTY destruction

## Context
Notifications would stop delivering over SSH and then burst all at once when opening a new tmux pane. Root cause: the watcher process died from SIGHUP (when its originating pane's PTY was destroyed), left a stale PID file, and notifications queued up until a new pane triggered a watcher restart.

## Test plan
- [ ] Run Ansible to propagate fish config to remote machine
- [ ] Kill existing tnotify-watch process and remove `~/.cache/tnotify.pid`
- [ ] Open a new tmux pane to start the updated watcher
- [ ] Verify Claude Code notifications arrive promptly over SSH
- [ ] Close the originating pane and confirm notifications continue working from other panes