### PR TITLE
feat(claude): hooks overhaul (worktree bootstrap + contextual notifications)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,8 +58,11 @@ directory requires a matching symlink task in `roles/osx/tasks/osx.yml`.
 trusts mise, then kicks off lockfile-detected dep installs in the background.
 Each repo may ship an executable `.claude/worktree-bootstrap` script for
 project-specific extra steps (codegen, DB setup, etc.). Marker:
-`.git/claude-bootstrap-done` (delete to force re-run). Log:
-`~/.claude/cache/worktree-bootstrap.log`.
+`.git/claude-bootstrap-done` (empty while running, `ok <ts>` on success;
+removed on failure so the next session retries). Log:
+`~/.claude/cache/worktree-bootstrap.log` (truncated when it exceeds ~256KB).
+In a primary checkout (`.git` is a directory, not a pointer file) the hook
+is a silent no-op by design.
 
 **Trust caveat:** the hook runs `.claude/worktree-bootstrap` from the repo
 with no sandboxing, so opening Claude in an untrusted checkout executes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,11 @@ project-specific extra steps (codegen, DB setup, etc.). Marker:
 `.git/claude-bootstrap-done` (delete to force re-run). Log:
 `~/.claude/cache/worktree-bootstrap.log`.
 
+**Trust caveat:** the hook runs `.claude/worktree-bootstrap` from the repo
+with no sandboxing, so opening Claude in an untrusted checkout executes
+whatever that script contains. Same trust model as `mise trust`: inspect the
+script before opening a repo you did not author.
+
 ## Do not edit directly in `~/.claude/`
 
 Any file symlinked from this repo is overwritten on the next Ansible run.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ runtime:
 |---|---|---|
 | `~/.claude/CLAUDE.md` | `roles/osx/files/CLAUDE.md` | Symlink (outside `claude/` subdirectory) |
 | `~/.claude/commands/*` | `roles/osx/files/claude/commands/` | Symlink |
+| `~/.claude/scripts/*` | `roles/osx/files/claude/scripts/` | Symlink (hook scripts invoked from `settings.json`) |
 | `~/.claude/settings.json` | `roles/osx/files/claude/settings.json` | jq merge (not symlink) |
 
 Always edit the tracked source. The materialized file in `~/.claude/` is
@@ -39,8 +40,25 @@ near-empty.
 3. Commit and run Ansible (or wait for the next symlink task run).
 4. Verify in a fresh Claude session.
 
-Skills and hooks are not managed by Ansible yet. Adding them requires a new
-tracked directory plus a matching symlink task in `roles/osx/tasks/osx.yml`.
+Hook logic lives in `roles/osx/files/claude/scripts/` and is wired from
+`settings.json`. Skills are not managed by Ansible yet. Adding a new tracked
+directory requires a matching symlink task in `roles/osx/tasks/osx.yml`.
+
+## Adding a new hook
+
+1. Write the script under `roles/osx/files/claude/scripts/` and `chmod +x` it.
+2. Reference it from `roles/osx/files/claude/settings.json` under `hooks.<Event>`
+   via `$HOME/.claude/scripts/<name>.sh`.
+3. To remove an existing hook event, set its array to `[]` in the tracked
+   `settings.json` so the jq merge overwrites the materialized entry.
+
+### Per-repo worktree bootstrap hook
+
+`scripts/worktree-bootstrap.sh` runs on `SessionStart`. In a git worktree it
+trusts mise, then kicks off lockfile-detected dep installs in the background.
+Each repo may ship an executable `.claude/worktree-bootstrap` script for
+project-specific extra steps (codegen, DB setup, etc.). Marker:
+`.git/claude-bootstrap-done` (delete to force re-run).
 
 ## Do not edit directly in `~/.claude/`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,8 +59,10 @@ In a git worktree it trusts mise, then kicks off lockfile-detected dep installs
 in the background.
 Each repo may ship an executable `.claude/worktree-bootstrap` script for
 project-specific extra steps (codegen, DB setup, etc.). Marker:
-`.git/claude-bootstrap-done` (empty while running, `ok <ts>` on success;
-removed on failure so the next session retries). Log:
+`claude-bootstrap-done` inside the per-worktree gitdir (resolve with
+`git rev-parse --git-dir`; in a worktree `.git` is a pointer file, so the
+marker is not under `<worktree>/.git/`). Empty while running, `ok <ts>` on
+success; removed on failure so the next session retries. Log:
 `~/.claude/cache/worktree-bootstrap.log` (truncated when it exceeds ~256KB).
 In a primary checkout (`.git` is a directory, not a pointer file) the hook
 is a silent no-op by design.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,8 @@ directory requires a matching symlink task in `roles/osx/tasks/osx.yml`.
 trusts mise, then kicks off lockfile-detected dep installs in the background.
 Each repo may ship an executable `.claude/worktree-bootstrap` script for
 project-specific extra steps (codegen, DB setup, etc.). Marker:
-`.git/claude-bootstrap-done` (delete to force re-run).
+`.git/claude-bootstrap-done` (delete to force re-run). Log:
+`~/.claude/cache/worktree-bootstrap.log`.
 
 ## Do not edit directly in `~/.claude/`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,8 +54,9 @@ directory requires a matching symlink task in `roles/osx/tasks/osx.yml`.
 
 ### Per-repo worktree bootstrap hook
 
-`scripts/worktree-bootstrap.sh` runs on `SessionStart`. In a git worktree it
-trusts mise, then kicks off lockfile-detected dep installs in the background.
+`roles/osx/files/claude/scripts/worktree-bootstrap.sh` runs on `SessionStart`.
+In a git worktree it trusts mise, then kicks off lockfile-detected dep installs
+in the background.
 Each repo may ship an executable `.claude/worktree-bootstrap` script for
 project-specific extra steps (codegen, DB setup, etc.). Marker:
 `.git/claude-bootstrap-done` (empty while running, `ok <ts>` on success;

--- a/roles/osx/files/claude/commands/self-review.md
+++ b/roles/osx/files/claude/commands/self-review.md
@@ -37,20 +37,27 @@ Do a comprehensive code review of the current feature branch.
 
 8. After all items are addressed, commit the changes.
 
-9. If the review found nothing substantive (or after addressing everything), offer to push and create a draft PR. Before creating it, check for PR templates and conventions:
+9. If the review found nothing substantive (or after addressing everything), offer to push the branch. Then handle the PR, gracefully reusing an existing one if present:
 
-   **Check for templates:**
+   **Check if a PR already exists for this branch:**
+   ```
+   gh pr view --json number,url,state,isDraft,title 2>/dev/null
+   ```
+   - If a PR exists: push the branch (`git push origin <branch>`) so the existing PR picks up the new commits. Report the existing PR's URL and state (draft/ready, open/merged). Do NOT create a new PR. If the existing PR is merged or closed, ask the user whether to reopen it or create a fresh one instead of assuming.
+   - If no PR exists: proceed with the template/convention check below and create a draft PR.
+
+   **Check for templates (only when creating a new PR):**
    - Look for `.github/pull_request_template.md`, `.github/PULL_REQUEST_TEMPLATE.md`, or templates in `.github/PULL_REQUEST_TEMPLATE/`
    - If a template exists, use it as the structure for the PR body, filling in the sections based on the branch changes
 
-   **Check for conventions:**
+   **Check for conventions (only when creating a new PR):**
    - If no template exists, look at recent merged PRs for patterns:
      ```
      gh pr list --state merged --limit 5 --json title,body
      ```
    - If a clear pattern emerges (e.g., consistent sections, formatting), follow it
 
-   **Create the PR:**
+   **Create the PR (only when none exists):**
    - If a template or convention was found, use `gh pr create --draft` with a `--title` and `--body` that follows the discovered format
    - If nothing was found, fall back to `gh pr create --draft --fill`
 

--- a/roles/osx/files/claude/scripts/notify-event.sh
+++ b/roles/osx/files/claude/scripts/notify-event.sh
@@ -11,7 +11,8 @@
 set -u
 
 event="${1:-unknown}"
-json=$(cat 2>/dev/null || printf '{}')
+json=$(cat)
+[ -z "$json" ] && json='{}'
 
 cwd=$(printf '%s' "$json" | jq -r '.cwd // empty' 2>/dev/null)
 [ -z "$cwd" ] && cwd="$PWD"

--- a/roles/osx/files/claude/scripts/notify-event.sh
+++ b/roles/osx/files/claude/scripts/notify-event.sh
@@ -47,5 +47,6 @@ sanitize() { printf '%s' "$1" | tr '\t\n' '  '; }
 title=$(sanitize "$title")
 body=$(sanitize "$body")
 
+# shellcheck disable=SC2016  # single quotes are intentional: fish does the expansion.
 TNOTIFY_TITLE="$title" TNOTIFY_BODY="$body" \
     fish -c 'tnotify-send $TNOTIFY_TITLE $TNOTIFY_BODY' >/dev/null 2>&1 || true

--- a/roles/osx/files/claude/scripts/notify-event.sh
+++ b/roles/osx/files/claude/scripts/notify-event.sh
@@ -17,7 +17,7 @@ json=$(cat)
 cwd=$(printf '%s' "$json" | jq -r '.cwd // empty' 2>/dev/null)
 [ -z "$cwd" ] && cwd="$PWD"
 project=$(basename "$cwd")
-branch=$(git -C "$cwd" branch --show-current 2>/dev/null | tr -d '\n\t' || true)
+branch=$(git -C "$cwd" branch --show-current 2>/dev/null | tr -d '\n\t')
 
 context="$project"
 [ -n "$branch" ] && context="$project · $branch"

--- a/roles/osx/files/claude/scripts/notify-event.sh
+++ b/roles/osx/files/claude/scripts/notify-event.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Notification helper for Claude Code hooks. Consumes the hook JSON on stdin
+# and queues a tnotify-send with project context so notifications are useful
+# when several Claude instances run in parallel.
+#
+# Usage: notify-event.sh <event>
+#   done        - task finished (Stop hook)
+#   permission  - permission prompt (Notification matcher=permission_prompt)
+#   idle        - idle prompt (Notification matcher=idle_prompt)
+
+set -u
+
+event="${1:-unknown}"
+json=$(cat 2>/dev/null || printf '{}')
+
+cwd=$(printf '%s' "$json" | jq -r '.cwd // empty' 2>/dev/null)
+[ -z "$cwd" ] && cwd="$PWD"
+project=$(basename "$cwd")
+branch=$(git -C "$cwd" branch --show-current 2>/dev/null | tr -d '\n\t' || true)
+
+context="$project"
+[ -n "$branch" ] && context="$project · $branch"
+
+case "$event" in
+    done)
+        title="Claude ✓"
+        body="Done in $context"
+        ;;
+    idle)
+        title="Claude ⏳"
+        body="Waiting for input · $context"
+        ;;
+    permission)
+        msg=$(printf '%s' "$json" | jq -r '.message // empty' 2>/dev/null)
+        [ -z "$msg" ] && msg="needs approval"
+        title="Claude ?"
+        body="$context · $msg"
+        ;;
+    *)
+        title="Claude"
+        body="$context"
+        ;;
+esac
+
+# Strip tabs/newlines (tnotify queue is tab-separated, newline-delimited).
+sanitize() { printf '%s' "$1" | tr '\t\n' '  '; }
+title=$(sanitize "$title")
+body=$(sanitize "$body")
+
+TNOTIFY_TITLE="$title" TNOTIFY_BODY="$body" \
+    fish -c 'tnotify-send $TNOTIFY_TITLE $TNOTIFY_BODY' >/dev/null 2>&1 || true

--- a/roles/osx/files/claude/scripts/worktree-bootstrap.sh
+++ b/roles/osx/files/claude/scripts/worktree-bootstrap.sh
@@ -3,7 +3,8 @@
 # Wired from ~/.claude/settings.json as a SessionStart hook.
 #
 # Behavior (runs once per worktree; marker at .git/claude-bootstrap-done):
-#   1. Exit quietly if not a git worktree or already bootstrapped.
+#   1. Exit quietly if not a git worktree or already bootstrapped. Primary
+#      checkouts (where .git is a directory) are intentionally skipped.
 #   2. Synchronously: `mise trust` the worktree so .mise.toml / .tool-versions
 #      are accepted. This is fast and fixes the first-use friction.
 #   3. In the background: run a best-effort dependency install based on
@@ -13,6 +14,13 @@
 #   4. If the repo ships an executable .claude/worktree-bootstrap script,
 #      invoke it after the language installers so projects can layer on
 #      additional steps (codegen, DB setup, etc.).
+#
+# Marker state machine (file: .git/claude-bootstrap-done):
+#   - Absent         → run bootstrap.
+#   - Empty          → bootstrap in progress (or crashed mid-run).
+#                      If mtime < 30 min old, assume in-progress and skip.
+#                      If mtime >= 30 min old, assume stale and retake.
+#   - "ok <ts>"      → previous run succeeded. Skip.
 #
 # To force a re-run: rm .git/claude-bootstrap-done in the worktree.
 
@@ -33,10 +41,26 @@ case "$gitdir" in
     *) gitdir="$cwd/$gitdir" ;;
 esac
 
+marker="$gitdir/claude-bootstrap-done"
+
+# State check: skip if a previous run succeeded, or if another session is
+# currently bootstrapping (empty marker, recent mtime). Reclaim a stale
+# empty marker older than 30 min (longer than any realistic installer run).
+if [ -f "$marker" ]; then
+    if grep -q '^ok' "$marker" 2>/dev/null; then
+        exit 0
+    fi
+    if [ -n "$(find "$marker" -mmin -30 -print 2>/dev/null)" ]; then
+        exit 0
+    fi
+    rm -f "$marker"
+fi
+
 # Atomic claim via noclobber: `set -C` makes `>` fail if the target exists,
 # so two concurrent SessionStart hooks can't both pass through here. Only
-# the winner proceeds to the installers below.
-marker="$gitdir/claude-bootstrap-done"
+# the winner proceeds to the installers below. The empty marker signals
+# "in progress" until the background subshell overwrites it with "ok" or
+# removes it on failure.
 if ! ( set -C; : > "$marker" ) 2>/dev/null; then
     exit 0
 fi
@@ -44,6 +68,12 @@ fi
 log_dir="$HOME/.claude/cache"
 log_file="$log_dir/worktree-bootstrap.log"
 mkdir -p "$log_dir"
+
+# Truncate log if it has grown past ~256KB. Cheap unbounded-growth guard.
+if [ -f "$log_file" ]; then
+    log_size=$(wc -c <"$log_file" 2>/dev/null || echo 0)
+    [ "$log_size" -gt 262144 ] && : > "$log_file"
+fi
 
 ts() { date '+%Y-%m-%dT%H:%M:%S'; }
 log() { printf '[%s] %s\n' "$(ts)" "$*" >>"$log_file"; }
@@ -118,8 +148,16 @@ has_repo_hook=0
     fi
 
     ran_any=0
-    [ $n -gt 0 ] && ran_any=1
+    [ "$n" -gt 0 ] && ran_any=1
     [ $has_repo_hook -eq 1 ] && ran_any=1
+
+    # Finalize the marker: "ok <ts>" on success (parent wrote empty marker),
+    # or remove it on failure so the next session retries.
+    if [ $succeeded -eq 1 ]; then
+        printf 'ok %s\n' "$(ts)" > "$marker"
+    else
+        rm -f "$marker"
+    fi
 
     if [ $ran_any -eq 1 ]; then
         if [ $succeeded -eq 1 ]; then

--- a/roles/osx/files/claude/scripts/worktree-bootstrap.sh
+++ b/roles/osx/files/claude/scripts/worktree-bootstrap.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Bootstrap a fresh git worktree when Claude Code starts in one.
+# Wired from ~/.claude/settings.json as a SessionStart hook.
+#
+# Behavior (runs once per worktree; marker at .git/claude-bootstrap-done):
+#   1. Exit quietly if not a git worktree or already bootstrapped.
+#   2. Synchronously: `mise trust` the worktree so .mise.toml / .tool-versions
+#      are accepted. This is fast and fixes the first-use friction.
+#   3. In the background: run a best-effort dependency install based on
+#      detected lockfiles (npm/yarn/pnpm, bundler, mix, cargo, go mod, uv,
+#      poetry). Logs go to ~/.claude/cache/worktree-bootstrap.log.
+#      A desktop notification fires when the install finishes.
+#   4. If the repo ships an executable .claude/worktree-bootstrap script,
+#      invoke it after the language installers so projects can layer on
+#      additional steps (codegen, DB setup, etc.).
+#
+# To force a re-run: rm .git/claude-bootstrap-done in the worktree.
+
+set -u
+
+cwd="${CLAUDE_PROJECT_DIR:-$PWD}"
+
+# Only interested in git worktrees. In a worktree, .git is a *file* pointing
+# at the per-worktree gitdir; in the primary checkout it's a directory.
+[ -f "$cwd/.git" ] || exit 0
+
+# Resolve the real per-worktree gitdir (the .git file is a pointer).
+gitdir=$(git -C "$cwd" rev-parse --git-dir 2>/dev/null)
+[ -n "$gitdir" ] || exit 0
+# Make absolute so a later `cd` in the background subshell doesn't break it.
+case "$gitdir" in
+    /*) ;;
+    *) gitdir="$cwd/$gitdir" ;;
+esac
+
+marker="$gitdir/claude-bootstrap-done"
+[ -f "$marker" ] && exit 0
+
+log_dir="$HOME/.claude/cache"
+log_file="$log_dir/worktree-bootstrap.log"
+mkdir -p "$log_dir"
+
+ts() { date '+%Y-%m-%dT%H:%M:%S'; }
+log() { printf '[%s] %s\n' "$(ts)" "$*" >>"$log_file"; }
+
+log "bootstrap start: $cwd"
+
+# Step 1: trust mise synchronously so subsequent tool invocations work.
+if [ -f "$cwd/.mise.toml" ] || [ -f "$cwd/mise.toml" ] || [ -f "$cwd/.tool-versions" ]; then
+    if command -v mise >/dev/null 2>&1; then
+        if mise trust "$cwd" >>"$log_file" 2>&1; then
+            log "mise trusted"
+        else
+            log "mise trust failed (continuing)"
+        fi
+    fi
+fi
+
+# Mark early so concurrent session starts don't double-run.
+touch "$marker"
+
+# Step 2: background dependency install.
+(
+    cd "$cwd" || exit 0
+    ran_any=0
+    succeeded=1
+
+    run() {
+        ran_any=1
+        log "run: $*"
+        if fish -c "cd '$cwd'; and $*" >>"$log_file" 2>&1; then
+            log "ok: $*"
+        else
+            log "fail: $*"
+            succeeded=0
+        fi
+    }
+
+    [ -f package-lock.json ] && run "npm ci"
+    [ -f yarn.lock ] && [ ! -f package-lock.json ] && run "yarn install --frozen-lockfile"
+    [ -f pnpm-lock.yaml ] && run "pnpm install --frozen-lockfile"
+    [ -f Gemfile.lock ] && run "bundle install"
+    [ -f mix.exs ] && run "mix deps.get"
+    [ -f go.mod ] && run "go mod download"
+    [ -f Cargo.lock ] && run "cargo fetch"
+    [ -f uv.lock ] && run "uv sync"
+    [ -f poetry.lock ] && run "poetry install --no-root"
+
+    # Per-repo hook: runs after language installers.
+    if [ -x ".claude/worktree-bootstrap" ]; then
+        ran_any=1
+        log "run: .claude/worktree-bootstrap"
+        if fish -c "cd '$cwd'; and ./.claude/worktree-bootstrap" >>"$log_file" 2>&1; then
+            log "ok: .claude/worktree-bootstrap"
+        else
+            log "fail: .claude/worktree-bootstrap"
+            succeeded=0
+        fi
+    fi
+
+    if [ $ran_any -eq 1 ]; then
+        if [ $succeeded -eq 1 ]; then
+            fish -c "tnotify-send 'Claude worktree' 'Bootstrap complete'" >/dev/null 2>&1 || true
+        else
+            fish -c "tnotify-send 'Claude worktree' 'Bootstrap had failures (see log)'" >/dev/null 2>&1 || true
+        fi
+    fi
+    log "bootstrap end (ran_any=$ran_any succeeded=$succeeded)"
+) >/dev/null 2>&1 &
+disown
+
+# Emit additionalContext so Claude knows this happened.
+detected=()
+[ -f "$cwd/package-lock.json" ] && detected+=("npm")
+[ -f "$cwd/yarn.lock" ] && [ ! -f "$cwd/package-lock.json" ] && detected+=("yarn")
+[ -f "$cwd/pnpm-lock.yaml" ] && detected+=("pnpm")
+[ -f "$cwd/Gemfile.lock" ] && detected+=("bundler")
+[ -f "$cwd/mix.exs" ] && detected+=("mix")
+[ -f "$cwd/go.mod" ] && detected+=("go")
+[ -f "$cwd/Cargo.lock" ] && detected+=("cargo")
+[ -f "$cwd/uv.lock" ] && detected+=("uv")
+[ -f "$cwd/poetry.lock" ] && detected+=("poetry")
+[ -x "$cwd/.claude/worktree-bootstrap" ] && detected+=("repo-bootstrap")
+
+if [ ${#detected[@]} -eq 0 ]; then
+    summary="Fresh git worktree detected. Trusted mise config if present. No package lockfiles or repo bootstrap script found."
+else
+    joined=$(IFS=, ; echo "${detected[*]}")
+    summary="Fresh git worktree detected. Trusted mise config; running installs in background: ${joined}. Log: ~/.claude/cache/worktree-bootstrap.log. Marker: .git/claude-bootstrap-done (delete to force re-run)."
+fi
+
+printf '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":%s}}\n' \
+    "$(printf '%s' "$summary" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')"
+
+exit 0

--- a/roles/osx/files/claude/scripts/worktree-bootstrap.sh
+++ b/roles/osx/files/claude/scripts/worktree-bootstrap.sh
@@ -36,6 +36,10 @@ esac
 marker="$gitdir/claude-bootstrap-done"
 [ -f "$marker" ] && exit 0
 
+# Claim the marker up-front so concurrent SessionStart hooks short-circuit
+# before they get to the (heavy) background installers below.
+touch "$marker"
+
 log_dir="$HOME/.claude/cache"
 log_file="$log_dir/worktree-bootstrap.log"
 mkdir -p "$log_dir"
@@ -55,9 +59,6 @@ if [ -f "$cwd/.mise.toml" ] || [ -f "$cwd/mise.toml" ] || [ -f "$cwd/.tool-versi
         fi
     fi
 fi
-
-# Mark early so concurrent session starts don't double-run.
-touch "$marker"
 
 # Step 2: background dependency install.
 (
@@ -130,6 +131,6 @@ else
 fi
 
 printf '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":%s}}\n' \
-    "$(printf '%s' "$summary" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')"
+    "$(printf '%s' "$summary" | jq -Rs .)"
 
 exit 0

--- a/roles/osx/files/claude/scripts/worktree-bootstrap.sh
+++ b/roles/osx/files/claude/scripts/worktree-bootstrap.sh
@@ -77,18 +77,18 @@ fi
         fi
     }
 
-    [ -f package-lock.json ] && run "npm ci"
-    [ -f yarn.lock ] && [ ! -f package-lock.json ] && run "yarn install --frozen-lockfile"
-    [ -f pnpm-lock.yaml ] && run "pnpm install --frozen-lockfile"
-    [ -f Gemfile.lock ] && run "bundle install"
-    [ -f mix.exs ] && run "mix deps.get"
-    [ -f go.mod ] && run "go mod download"
-    [ -f Cargo.lock ] && run "cargo fetch"
-    [ -f uv.lock ] && run "uv sync"
-    [ -f poetry.lock ] && run "poetry install --no-root"
+    [ -f "$cwd/package-lock.json" ] && run "npm ci"
+    [ -f "$cwd/yarn.lock" ] && [ ! -f "$cwd/package-lock.json" ] && run "yarn install --frozen-lockfile"
+    [ -f "$cwd/pnpm-lock.yaml" ] && [ ! -f "$cwd/package-lock.json" ] && run "pnpm install --frozen-lockfile"
+    [ -f "$cwd/Gemfile.lock" ] && run "bundle install"
+    [ -f "$cwd/mix.exs" ] && run "mix deps.get"
+    [ -f "$cwd/go.mod" ] && run "go mod download"
+    [ -f "$cwd/Cargo.lock" ] && run "cargo fetch"
+    [ -f "$cwd/uv.lock" ] && run "uv sync"
+    [ -f "$cwd/poetry.lock" ] && run "poetry install --no-root"
 
     # Per-repo hook: runs after language installers.
-    if [ -x ".claude/worktree-bootstrap" ]; then
+    if [ -x "$cwd/.claude/worktree-bootstrap" ]; then
         ran_any=1
         log "run: .claude/worktree-bootstrap"
         if fish -c "cd '$cwd'; and ./.claude/worktree-bootstrap" >>"$log_file" 2>&1; then
@@ -114,7 +114,7 @@ disown
 detected=()
 [ -f "$cwd/package-lock.json" ] && detected+=("npm")
 [ -f "$cwd/yarn.lock" ] && [ ! -f "$cwd/package-lock.json" ] && detected+=("yarn")
-[ -f "$cwd/pnpm-lock.yaml" ] && detected+=("pnpm")
+[ -f "$cwd/pnpm-lock.yaml" ] && [ ! -f "$cwd/package-lock.json" ] && detected+=("pnpm")
 [ -f "$cwd/Gemfile.lock" ] && detected+=("bundler")
 [ -f "$cwd/mix.exs" ] && detected+=("mix")
 [ -f "$cwd/go.mod" ] && detected+=("go")

--- a/roles/osx/files/claude/scripts/worktree-bootstrap.sh
+++ b/roles/osx/files/claude/scripts/worktree-bootstrap.sh
@@ -190,7 +190,7 @@ fi
 if [ -z "$joined" ]; then
     summary="Fresh git worktree detected. Trusted mise config if present. No package lockfiles or repo bootstrap script found."
 else
-    summary="Fresh git worktree detected. Trusted mise config; running installs in background: ${joined}. Log: ~/.claude/cache/worktree-bootstrap.log. Marker: ${marker} (delete to force re-run)."
+    summary="Fresh git worktree detected. Trusted mise config if present; running installs in background: ${joined}. Log: ~/.claude/cache/worktree-bootstrap.log. Marker: ${marker} (delete to force re-run)."
 fi
 
 printf '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":%s}}\n' \

--- a/roles/osx/files/claude/scripts/worktree-bootstrap.sh
+++ b/roles/osx/files/claude/scripts/worktree-bootstrap.sh
@@ -2,7 +2,8 @@
 # Bootstrap a fresh git worktree when Claude Code starts in one.
 # Wired from ~/.claude/settings.json as a SessionStart hook.
 #
-# Behavior (runs once per worktree; marker at .git/claude-bootstrap-done):
+# Behavior (runs once per worktree; marker at <gitdir>/claude-bootstrap-done,
+# where <gitdir> is the per-worktree gitdir resolved via `git rev-parse --git-dir`):
 #   1. Exit quietly if not a git worktree or already bootstrapped. Primary
 #      checkouts (where .git is a directory) are intentionally skipped.
 #   2. Synchronously: `mise trust` the worktree so .mise.toml / .tool-versions
@@ -15,14 +16,16 @@
 #      invoke it after the language installers so projects can layer on
 #      additional steps (codegen, DB setup, etc.).
 #
-# Marker state machine (file: .git/claude-bootstrap-done):
+# Marker state machine (file: <gitdir>/claude-bootstrap-done):
 #   - Absent         → run bootstrap.
 #   - Empty          → bootstrap in progress (or crashed mid-run).
 #                      If mtime < 30 min old, assume in-progress and skip.
 #                      If mtime >= 30 min old, assume stale and retake.
 #   - "ok <ts>"      → previous run succeeded. Skip.
 #
-# To force a re-run: rm .git/claude-bootstrap-done in the worktree.
+# To force a re-run: rm "$(git rev-parse --git-dir)/claude-bootstrap-done"
+# (the marker lives in the per-worktree gitdir, not in the worktree root,
+# because .git is a pointer file in a worktree).
 
 set -u
 
@@ -187,7 +190,7 @@ fi
 if [ -z "$joined" ]; then
     summary="Fresh git worktree detected. Trusted mise config if present. No package lockfiles or repo bootstrap script found."
 else
-    summary="Fresh git worktree detected. Trusted mise config; running installs in background: ${joined}. Log: ~/.claude/cache/worktree-bootstrap.log. Marker: .git/claude-bootstrap-done (delete to force re-run)."
+    summary="Fresh git worktree detected. Trusted mise config; running installs in background: ${joined}. Log: ~/.claude/cache/worktree-bootstrap.log. Marker: ${marker} (delete to force re-run)."
 fi
 
 printf '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":%s}}\n' \

--- a/roles/osx/files/claude/scripts/worktree-bootstrap.sh
+++ b/roles/osx/files/claude/scripts/worktree-bootstrap.sh
@@ -71,8 +71,8 @@ mkdir -p "$log_dir"
 
 # Truncate log if it has grown past ~256KB. Cheap unbounded-growth guard.
 if [ -f "$log_file" ]; then
-    log_size=$(wc -c <"$log_file" 2>/dev/null || echo 0)
-    [ "$log_size" -gt 262144 ] && : > "$log_file"
+    log_size=$(wc -c <"$log_file" 2>/dev/null | tr -d '[:space:]')
+    [ -n "$log_size" ] && [ "$log_size" -gt 262144 ] && : > "$log_file"
 fi
 
 ts() { date '+%Y-%m-%dT%H:%M:%S'; }
@@ -168,7 +168,7 @@ has_repo_hook=0
     fi
     log "bootstrap end (ran_any=$ran_any succeeded=$succeeded)"
 ) >/dev/null 2>&1 &
-disown
+disown 2>/dev/null || true
 
 # Emit additionalContext so Claude knows this happened. Build the joined
 # list with an index-based loop to keep bash-3.2 + `set -u` happy on

--- a/roles/osx/files/claude/scripts/worktree-bootstrap.sh
+++ b/roles/osx/files/claude/scripts/worktree-bootstrap.sh
@@ -122,7 +122,7 @@ has_repo_hook=0
 # the fish children inherit that working directory — no inner cd inside
 # `fish -c`, which also avoids quoting pitfalls if $cwd contains odd chars.
 (
-    cd "$cwd" || exit 0
+    cd "$cwd" || { rm -f "$marker"; exit 0; }
     n=${#installer_cmds[@]}
     succeeded=1
 

--- a/roles/osx/files/claude/scripts/worktree-bootstrap.sh
+++ b/roles/osx/files/claude/scripts/worktree-bootstrap.sh
@@ -7,7 +7,7 @@
 #   2. Synchronously: `mise trust` the worktree so .mise.toml / .tool-versions
 #      are accepted. This is fast and fixes the first-use friction.
 #   3. In the background: run a best-effort dependency install based on
-#      detected lockfiles (npm/yarn/pnpm, bundler, mix, cargo, go mod, uv,
+#      detected lockfiles (npm/pnpm/yarn, bundler, mix, cargo, go mod, uv,
 #      poetry). Logs go to ~/.claude/cache/worktree-bootstrap.log.
 #      A desktop notification fires when the install finishes.
 #   4. If the repo ships an executable .claude/worktree-bootstrap script,
@@ -33,12 +33,13 @@ case "$gitdir" in
     *) gitdir="$cwd/$gitdir" ;;
 esac
 
+# Atomic claim via noclobber: `set -C` makes `>` fail if the target exists,
+# so two concurrent SessionStart hooks can't both pass through here. Only
+# the winner proceeds to the installers below.
 marker="$gitdir/claude-bootstrap-done"
-[ -f "$marker" ] && exit 0
-
-# Claim the marker up-front so concurrent SessionStart hooks short-circuit
-# before they get to the (heavy) background installers below.
-touch "$marker"
+if ! ( set -C; : > "$marker" ) 2>/dev/null; then
+    exit 0
+fi
 
 log_dir="$HOME/.claude/cache"
 log_file="$log_dir/worktree-bootstrap.log"
@@ -60,44 +61,65 @@ if [ -f "$cwd/.mise.toml" ] || [ -f "$cwd/mise.toml" ] || [ -f "$cwd/.tool-versi
     fi
 fi
 
-# Step 2: background dependency install.
+# Detect package managers once. Same list drives both the background
+# installer and the additionalContext summary, so adding a new language is
+# a single-site change. Node package managers are mutually exclusive:
+# precedence npm > pnpm > yarn.
+detected_names=()
+installer_cmds=()
+
+add_installer() {
+    detected_names+=("$1")
+    installer_cmds+=("$2")
+}
+
+has_npm=0
+has_pnpm=0
+[ -f "$cwd/package-lock.json" ] && { has_npm=1; add_installer "npm" "npm ci"; }
+[ -f "$cwd/pnpm-lock.yaml" ] && [ $has_npm -eq 0 ] && { has_pnpm=1; add_installer "pnpm" "pnpm install --frozen-lockfile"; }
+[ -f "$cwd/yarn.lock" ] && [ $has_npm -eq 0 ] && [ $has_pnpm -eq 0 ] && add_installer "yarn" "yarn install --frozen-lockfile"
+[ -f "$cwd/Gemfile.lock" ] && add_installer "bundler" "bundle install"
+[ -f "$cwd/mix.exs" ] && add_installer "mix" "mix deps.get"
+[ -f "$cwd/go.mod" ] && add_installer "go" "go mod download"
+[ -f "$cwd/Cargo.lock" ] && add_installer "cargo" "cargo fetch"
+[ -f "$cwd/uv.lock" ] && add_installer "uv" "uv sync"
+[ -f "$cwd/poetry.lock" ] && add_installer "poetry" "poetry install --no-root"
+
+has_repo_hook=0
+[ -x "$cwd/.claude/worktree-bootstrap" ] && has_repo_hook=1
+
+# Step 2: background dependency install. The subshell cd's to $cwd once, so
+# the fish children inherit that working directory — no inner cd inside
+# `fish -c`, which also avoids quoting pitfalls if $cwd contains odd chars.
 (
     cd "$cwd" || exit 0
-    ran_any=0
+    n=${#installer_cmds[@]}
     succeeded=1
 
-    run() {
-        ran_any=1
-        log "run: $*"
-        if fish -c "cd '$cwd'; and $*" >>"$log_file" 2>&1; then
-            log "ok: $*"
+    for ((i=0; i<n; i++)); do
+        cmd="${installer_cmds[$i]}"
+        log "run: $cmd"
+        if fish -c "$cmd" >>"$log_file" 2>&1; then
+            log "ok: $cmd"
         else
-            log "fail: $*"
+            log "fail: $cmd"
             succeeded=0
         fi
-    }
+    done
 
-    [ -f "$cwd/package-lock.json" ] && run "npm ci"
-    [ -f "$cwd/yarn.lock" ] && [ ! -f "$cwd/package-lock.json" ] && run "yarn install --frozen-lockfile"
-    [ -f "$cwd/pnpm-lock.yaml" ] && [ ! -f "$cwd/package-lock.json" ] && run "pnpm install --frozen-lockfile"
-    [ -f "$cwd/Gemfile.lock" ] && run "bundle install"
-    [ -f "$cwd/mix.exs" ] && run "mix deps.get"
-    [ -f "$cwd/go.mod" ] && run "go mod download"
-    [ -f "$cwd/Cargo.lock" ] && run "cargo fetch"
-    [ -f "$cwd/uv.lock" ] && run "uv sync"
-    [ -f "$cwd/poetry.lock" ] && run "poetry install --no-root"
-
-    # Per-repo hook: runs after language installers.
-    if [ -x "$cwd/.claude/worktree-bootstrap" ]; then
-        ran_any=1
+    if [ $has_repo_hook -eq 1 ]; then
         log "run: .claude/worktree-bootstrap"
-        if fish -c "cd '$cwd'; and ./.claude/worktree-bootstrap" >>"$log_file" 2>&1; then
+        if fish -c "./.claude/worktree-bootstrap" >>"$log_file" 2>&1; then
             log "ok: .claude/worktree-bootstrap"
         else
             log "fail: .claude/worktree-bootstrap"
             succeeded=0
         fi
     fi
+
+    ran_any=0
+    [ $n -gt 0 ] && ran_any=1
+    [ $has_repo_hook -eq 1 ] && ran_any=1
 
     if [ $ran_any -eq 1 ]; then
         if [ $succeeded -eq 1 ]; then
@@ -110,23 +132,23 @@ fi
 ) >/dev/null 2>&1 &
 disown
 
-# Emit additionalContext so Claude knows this happened.
-detected=()
-[ -f "$cwd/package-lock.json" ] && detected+=("npm")
-[ -f "$cwd/yarn.lock" ] && [ ! -f "$cwd/package-lock.json" ] && detected+=("yarn")
-[ -f "$cwd/pnpm-lock.yaml" ] && [ ! -f "$cwd/package-lock.json" ] && detected+=("pnpm")
-[ -f "$cwd/Gemfile.lock" ] && detected+=("bundler")
-[ -f "$cwd/mix.exs" ] && detected+=("mix")
-[ -f "$cwd/go.mod" ] && detected+=("go")
-[ -f "$cwd/Cargo.lock" ] && detected+=("cargo")
-[ -f "$cwd/uv.lock" ] && detected+=("uv")
-[ -f "$cwd/poetry.lock" ] && detected+=("poetry")
-[ -x "$cwd/.claude/worktree-bootstrap" ] && detected+=("repo-bootstrap")
+# Emit additionalContext so Claude knows this happened. Build the joined
+# list with an index-based loop to keep bash-3.2 + `set -u` happy on
+# empty arrays.
+joined=""
+total=${#detected_names[@]}
+for ((i=0; i<total; i++)); do
+    [ -n "$joined" ] && joined="$joined,"
+    joined="$joined${detected_names[$i]}"
+done
+if [ $has_repo_hook -eq 1 ]; then
+    [ -n "$joined" ] && joined="$joined,"
+    joined="${joined}repo-bootstrap"
+fi
 
-if [ ${#detected[@]} -eq 0 ]; then
+if [ -z "$joined" ]; then
     summary="Fresh git worktree detected. Trusted mise config if present. No package lockfiles or repo bootstrap script found."
 else
-    joined=$(IFS=, ; echo "${detected[*]}")
     summary="Fresh git worktree detected. Trusted mise config; running installs in background: ${joined}. Log: ~/.claude/cache/worktree-bootstrap.log. Marker: .git/claude-bootstrap-done (delete to force re-run)."
 fi
 

--- a/roles/osx/files/claude/scripts/worktree-bootstrap.sh
+++ b/roles/osx/files/claude/scripts/worktree-bootstrap.sh
@@ -33,11 +33,21 @@ cwd="${CLAUDE_PROJECT_DIR:-$PWD}"
 
 # Only interested in git worktrees. In a worktree, .git is a *file* pointing
 # at the per-worktree gitdir; in the primary checkout it's a directory.
+# Note: submodules also use a `.git` pointer file, so the file check alone
+# is ambiguous. The gitdir vs git-common-dir comparison below is the real
+# worktree predicate.
 [ -f "$cwd/.git" ] || exit 0
 
 # Resolve the real per-worktree gitdir (the .git file is a pointer).
 gitdir=$(git -C "$cwd" rev-parse --git-dir 2>/dev/null)
 [ -n "$gitdir" ] || exit 0
+# In a linked worktree, --git-dir points at <main>/.git/worktrees/<name> while
+# --git-common-dir points at <main>/.git (they differ). In a primary checkout
+# and in submodules, the two paths resolve to the same directory. Bail if
+# they match so submodules aren't mistaken for worktrees.
+common_dir=$(git -C "$cwd" rev-parse --git-common-dir 2>/dev/null)
+[ -n "$common_dir" ] || exit 0
+[ "$gitdir" != "$common_dir" ] || exit 0
 # Make absolute so a later `cd` in the background subshell doesn't break it.
 case "$gitdir" in
     /*) ;;
@@ -84,12 +94,18 @@ log() { printf '[%s] %s\n' "$(ts)" "$*" >>"$log_file"; }
 log "bootstrap start: $cwd"
 
 # Step 1: trust mise synchronously so subsequent tool invocations work.
+# mise_status: "ok" if trust succeeded, "failed" if it ran but errored, or
+# empty if no mise config is present / mise isn't installed. The summary
+# below uses this so it doesn't falsely claim trust on a failure.
+mise_status=""
 if [ -f "$cwd/.mise.toml" ] || [ -f "$cwd/mise.toml" ] || [ -f "$cwd/.tool-versions" ]; then
     if command -v mise >/dev/null 2>&1; then
         if mise trust "$cwd" >>"$log_file" 2>&1; then
             log "mise trusted"
+            mise_status="ok"
         else
             log "mise trust failed (continuing)"
+            mise_status="failed"
         fi
     fi
 fi
@@ -187,10 +203,16 @@ if [ $has_repo_hook -eq 1 ]; then
     joined="${joined}repo-bootstrap"
 fi
 
+case "$mise_status" in
+    ok)     mise_phrase="Trusted mise config" ;;
+    failed) mise_phrase="mise trust failed (see log)" ;;
+    *)      mise_phrase="No mise config to trust" ;;
+esac
+
 if [ -z "$joined" ]; then
-    summary="Fresh git worktree detected. Trusted mise config if present. No package lockfiles or repo bootstrap script found."
+    summary="Fresh git worktree detected. ${mise_phrase}. No package lockfiles or repo bootstrap script found."
 else
-    summary="Fresh git worktree detected. Trusted mise config if present; running installs in background: ${joined}. Log: ~/.claude/cache/worktree-bootstrap.log. Marker: ${marker} (delete to force re-run)."
+    summary="Fresh git worktree detected. ${mise_phrase}; running installs in background: ${joined}. Log: ~/.claude/cache/worktree-bootstrap.log. Marker: ${marker} (delete to force re-run)."
 fi
 
 printf '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":%s}}\n' \

--- a/roles/osx/files/claude/settings.json
+++ b/roles/osx/files/claude/settings.json
@@ -4,12 +4,22 @@
     "pr": ""
   },
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/scripts/worktree-bootstrap.sh"
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [
           {
             "type": "command",
-            "command": "fish -c \"tnotify-send 'Claude Code' 'Task completed'\""
+            "command": "$HOME/.claude/scripts/notify-event.sh done"
           }
         ]
       }
@@ -20,7 +30,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "msg=$(cat | jq -r '.message') && fish -c \"tnotify-send 'Claude Code' \\\"$msg\\\"\""
+            "command": "$HOME/.claude/scripts/notify-event.sh permission"
           }
         ]
       },
@@ -29,21 +39,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "fish -c \"tnotify-send 'Claude Code' 'Waiting for input'\""
+            "command": "$HOME/.claude/scripts/notify-event.sh idle"
           }
         ]
       }
     ],
-    "SubagentStop": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "fish -c \"tnotify-send 'Claude Code' 'Subagent completed'\""
-          }
-        ]
-      }
-    ]
+    "SubagentStop": []
   },
   "enabledPlugins": {
     "pyright-lsp@claude-plugins-official": true,

--- a/roles/osx/tasks/osx.yml
+++ b/roles/osx/tasks/osx.yml
@@ -52,6 +52,13 @@
     state: link
   tags: [osx]
 
+- name: Symlink Claude hook scripts
+  ansible.builtin.file:
+    src: "{{ ansible_env.PWD }}/roles/osx/files/claude/scripts"
+    dest: "{{ ansible_env.HOME }}/.claude/scripts"
+    state: link
+  tags: [osx]
+
 - name: Create Cursor rules directory
   ansible.builtin.file:
     path: "{{ ansible_env.HOME }}/.cursor/rules"

--- a/specs/claude-context/requirements.md
+++ b/specs/claude-context/requirements.md
@@ -65,8 +65,10 @@ have something non-obvious to say; sections that do not may be omitted:
 - **Adding a new Claude command.** The path and propagation: drop the file under
   `roles/osx/files/claude/commands/`, commit, let the Ansible symlink task pick
   it up, verify in a fresh session. Command front-matter is required for
-  discovery. Adding skills or hooks is out of scope for this section until those
-  surfaces are managed by Ansible (new tracked directory plus symlink task).
+  discovery. Hook scripts are now managed under `roles/osx/files/claude/scripts/`
+  with a matching symlink task and are wired from `settings.json`. Skills are
+  still out of scope for this section and would require a new tracked directory
+  plus symlink task.
 - **Things to NOT edit directly in `~/.claude/`.** Anything symlinked from this
   repo. If in doubt, `readlink` the file first.
 - **Ansible role layout pointer.** A single-line hint that `roles/osx/` is the Mac

--- a/specs/claude-context/requirements.md
+++ b/specs/claude-context/requirements.md
@@ -48,13 +48,14 @@ have something non-obvious to say; sections that do not may be omitted:
 - **How Claude config is materialized.** The non-obvious fact that the tracked
   Claude sources live in the Ansible role and are materialized by different
   mechanisms: `roles/osx/files/claude/commands/` is symlinked into
-  `~/.claude/commands/`, `~/.claude/CLAUDE.md` is symlinked from
-  `roles/osx/files/CLAUDE.md` (note: outside the `claude/` directory), and
-  `roles/osx/files/claude/settings.json` is merged into `~/.claude/settings.json`
-  by a jq-based task rather than symlinked. Editing the materialized file
-  directly is wrong; edit the tracked source. Adding new surfaces (skills, hooks)
-  requires creating the tracked directory and matching management in
-  `roles/osx/tasks/osx.yml`.
+  `~/.claude/commands/`, `roles/osx/files/claude/scripts/` is symlinked into
+  `~/.claude/scripts/` (hook scripts invoked from `settings.json`),
+  `~/.claude/CLAUDE.md` is symlinked from `roles/osx/files/CLAUDE.md` (note:
+  outside the `claude/` directory), and `roles/osx/files/claude/settings.json`
+  is merged into `~/.claude/settings.json` by a jq-based task rather than
+  symlinked. Editing the materialized file directly is wrong; edit the tracked
+  source. Adding further surfaces (e.g., skills) requires creating the tracked
+  directory and matching management in `roles/osx/tasks/osx.yml`.
 - **Permissions three-layer model.** A compact restatement of #8's decision:
   global `~/.claude/settings.json` (tracked via this repo) for durable cross-project
   allows plus the deny list; per-repo tracked `.claude/settings.json` for

--- a/specs/claude-context/tasks.md
+++ b/specs/claude-context/tasks.md
@@ -15,10 +15,12 @@ Target 120 lines (hard ceiling 200). Sections, in order:
    edits land here, Ansible run propagates.
 2. **How Claude config is materialized** — tracked Claude sources live in the
    Ansible role: `roles/osx/files/claude/commands/` is symlinked into
-   `~/.claude/commands/`, `~/.claude/CLAUDE.md` is symlinked from
-   `roles/osx/files/CLAUDE.md` (outside the `claude/` directory), and
-   `settings.json` is produced by a jq merge/write task rather than symlinked.
-   Edit the tracked source, not the materialized file in `~/.claude/`.
+   `~/.claude/commands/`, `roles/osx/files/claude/scripts/` is symlinked into
+   `~/.claude/scripts/` (hook scripts invoked from `settings.json`),
+   `~/.claude/CLAUDE.md` is symlinked from `roles/osx/files/CLAUDE.md`
+   (outside the `claude/` directory), and `settings.json` is produced by a jq
+   merge/write task rather than symlinked. Edit the tracked source, not the
+   materialized file in `~/.claude/`.
 3. **Permissions three-layer model** — compact restatement of #8's resolved model
    (global tracked, per-repo tracked, per-repo local). Note that the dotfiles
    `.claude/settings.json` (tracked, created in #8) holds dotfiles-specific durable

--- a/specs/claude-context/tasks.md
+++ b/specs/claude-context/tasks.md
@@ -26,9 +26,11 @@ Target 120 lines (hard ceiling 200). Sections, in order:
 4. **Adding a new Claude command** — drop the file under
    `roles/osx/files/claude/commands/`, commit, run Ansible (or let the symlink
    task pick it up on its next run), verify in a fresh session. Command
-   front-matter required for discovery. Skills/hooks are not currently managed
-   by Ansible; adding them would require a new tracked directory plus a matching
-   symlink task and is out of scope here.
+   front-matter required for discovery. Hook scripts live under
+   `roles/osx/files/claude/scripts/` and are symlinked by a matching task in
+   `roles/osx/tasks/osx.yml`; they are wired from `settings.json`. Skills are
+   not yet managed by Ansible; adding them would require a new tracked
+   directory plus a matching symlink task and is out of scope here.
 5. **Things to NOT edit directly in `~/.claude/`** — anything symlinked from this
    repo. If in doubt, `readlink` first.
 6. **Ansible role layout pointer** — one line: `roles/osx/` is the Mac role; most


### PR DESCRIPTION
## Summary

- **New `SessionStart` hook** (`scripts/worktree-bootstrap.sh`): in a fresh git worktree, synchronously `mise trust`s the tree and then kicks off lockfile-detected dep installs (npm/yarn/pnpm, bundler, mix, go mod, cargo, uv, poetry) in the background. Runs once per worktree (marker at `.git/claude-bootstrap-done`). Honors an optional executable `.claude/worktree-bootstrap` per-repo script for codegen/DB setup/etc.
- **Contextual notifications** (`scripts/notify-event.sh`): `Stop` / `Notification(permission_prompt|idle_prompt)` hooks now queue `tnotify-send` with `project · branch` context and event-specific titles, so notifications are disambiguable when multiple Claude instances run in parallel. `SubagentStop` notifications are retired (array cleared).
- **Ansible**: new symlink task for `roles/osx/files/claude/scripts/` → `~/.claude/scripts/`.
- **`self-review` command**: gracefully reuses an existing PR on re-push instead of failing `gh pr create`; only runs template/convention discovery when creating a new PR.
- **`CLAUDE.md`**: documents the scripts directory, the "adding a new hook" flow, and the worktree-bootstrap contract (marker, log path, per-repo hook).

## Self-review notes

Fixes applied during review:

- Claim the bootstrap marker before `mise trust` so concurrent `SessionStart` hooks in the same worktree cannot both spawn background installers.
- Swap the `python3`-based `additionalContext` JSON escape for `jq -Rs .` (one fewer soft dependency; `jq` is already required by the settings-merge task).
- Silence a false-positive shellcheck SC2016 on the intentional fish-expansion single quotes in `notify-event.sh`.

## Test plan

- [x] `shellcheck` passes clean on both new scripts
- [x] `jq -Rs .` output confirmed parseable as the `additionalContext` string (tested with quotes/tabs/newlines)
- [x] Bootstrap log shows a successful mix deps.get run on a live worktree
- [ ] Open a fresh worktree in a polyglot repo, confirm `mise trust` fires, background install runs, `tnotify-send 'Claude worktree' 'Bootstrap complete'` arrives
- [ ] Trigger a permission prompt and confirm the notification body includes `project · branch · <message>`
- [ ] Confirm `Stop` notifications say `Done in project · branch`
- [ ] Re-run `/self-review` on a branch that already has a PR and verify it pushes instead of attempting to create a duplicate