### PR TITLE
fix(homebrew): prevent sudo TTY failures on mas app upgrades

### DIFF
--- a/roles/osx/tasks/homebrew.yml
+++ b/roles/osx/tasks/homebrew.yml
@@ -2,14 +2,14 @@
 
 - name: Install common packages from Brewfile
   ansible.builtin.command:
-    cmd: brew bundle --file={{ ansible_env.PWD }}/Brewfile
+    cmd: brew bundle install --no-upgrade --file={{ ansible_env.PWD }}/Brewfile
   register: osx_brew_bundle_common
   changed_when: "'Installing' in osx_brew_bundle_common.stdout"
   tags: [osx]
 
 - name: Install host-specific packages from Brewfile
   ansible.builtin.command:
-    cmd: brew bundle --file={{ ansible_env.PWD }}/Brewfile.{{ inventory_hostname }}
+    cmd: brew bundle install --no-upgrade --file={{ ansible_env.PWD }}/Brewfile.{{ inventory_hostname }}
   register: osx_brew_bundle_host
   changed_when: "'Installing' in osx_brew_bundle_host.stdout"
   tags: [osx]

--- a/roles/osx/tasks/upgrade.yml
+++ b/roles/osx/tasks/upgrade.yml
@@ -5,9 +5,27 @@
     update_homebrew: true
   tags: [upgrade]
 
+# mas entries are skipped in brew bundle (it shells out via sudo, which fails
+# without a TTY for apps owned by root:wheel in /Applications). The separate
+# "Upgrade MAS apps" task below handles mas with failed_when: false.
+- name: Collect MAS app IDs to skip in brew bundle
+  ansible.builtin.shell:
+    cmd: >-
+      set -o pipefail;
+      cat {{ ansible_env.PWD }}/Brewfile {{ ansible_env.PWD }}/Brewfile.{{ inventory_hostname }}
+      | grep -oE 'id:[[:space:]]*[0-9]+'
+      | grep -oE '[0-9]+'
+      | tr '\n' ' '
+    executable: /bin/bash
+  register: osx_brewfile_mas_ids
+  changed_when: false
+  tags: [upgrade]
+
 - name: Upgrade common packages from Brewfile
   ansible.builtin.command:
     cmd: brew bundle --file={{ ansible_env.PWD }}/Brewfile
+  environment:
+    HOMEBREW_BUNDLE_MAS_SKIP: "{{ osx_brewfile_mas_ids.stdout }}"
   register: osx_brew_bundle_common
   changed_when: "'Installing' in osx_brew_bundle_common.stdout or 'Upgrading' in osx_brew_bundle_common.stdout"
   tags: [upgrade]
@@ -15,6 +33,8 @@
 - name: Upgrade host-specific packages from Brewfile
   ansible.builtin.command:
     cmd: brew bundle --file={{ ansible_env.PWD }}/Brewfile.{{ inventory_hostname }}
+  environment:
+    HOMEBREW_BUNDLE_MAS_SKIP: "{{ osx_brewfile_mas_ids.stdout }}"
   register: osx_brew_bundle_host
   changed_when: "'Installing' in osx_brew_bundle_host.stdout or 'Upgrading' in osx_brew_bundle_host.stdout"
   tags: [upgrade]

--- a/roles/osx/tasks/upgrade.yml
+++ b/roles/osx/tasks/upgrade.yml
@@ -5,16 +5,35 @@
     update_homebrew: true
   tags: [upgrade]
 
-# mas entries are skipped in brew bundle (it shells out via sudo, which fails
-# without a TTY for apps owned by root:wheel in /Applications). The separate
-# "Upgrade MAS apps" task below handles mas with failed_when: false.
-- name: Collect MAS app IDs to skip in brew bundle
+# Install-missing pass runs first without MAS_SKIP so newly-added mas entries
+# get installed during `mise run upgrade` (fresh mas installs don't need sudo).
+# --no-upgrade leaves already-installed mas apps as "Using", so the root:wheel
+# sudo prompt is avoided.
+- name: Install missing packages from Brewfile
+  ansible.builtin.command:
+    cmd: brew bundle install --no-upgrade --file={{ ansible_env.PWD }}/Brewfile
+  register: osx_brew_bundle_common_install
+  changed_when: "'Installing' in osx_brew_bundle_common_install.stdout"
+  tags: [upgrade]
+
+- name: Install missing host-specific packages from Brewfile
+  ansible.builtin.command:
+    cmd: brew bundle install --no-upgrade --file={{ ansible_env.PWD }}/Brewfile.{{ inventory_hostname }}
+  register: osx_brew_bundle_host_install
+  changed_when: "'Installing' in osx_brew_bundle_host_install.stdout"
+  tags: [upgrade]
+
+# mas entries are skipped in the upgrade pass below (brew bundle shells out via
+# sudo for mas apps owned by root:wheel in /Applications, which fails without a
+# TTY). The separate "Upgrade MAS apps" task handles mas with failed_when:
+# false.
+- name: Collect MAS app IDs to skip in brew bundle upgrade
   ansible.builtin.shell:
     cmd: >-
       set -o pipefail;
       cat {{ ansible_env.PWD }}/Brewfile {{ ansible_env.PWD }}/Brewfile.{{ inventory_hostname }}
-      | grep -oE 'id:[[:space:]]*[0-9]+'
-      | grep -oE '[0-9]+'
+      | { grep -oE 'id:[[:space:]]*[0-9]+'
+      | grep -oE '[0-9]+' || true; }
       | tr '\n' ' '
     executable: /bin/bash
   register: osx_brewfile_mas_ids
@@ -27,7 +46,7 @@
   environment:
     HOMEBREW_BUNDLE_MAS_SKIP: "{{ osx_brewfile_mas_ids.stdout }}"
   register: osx_brew_bundle_common
-  changed_when: "'Installing' in osx_brew_bundle_common.stdout or 'Upgrading' in osx_brew_bundle_common.stdout"
+  changed_when: "'Upgrading' in osx_brew_bundle_common.stdout"
   tags: [upgrade]
 
 - name: Upgrade host-specific packages from Brewfile
@@ -36,7 +55,7 @@
   environment:
     HOMEBREW_BUNDLE_MAS_SKIP: "{{ osx_brewfile_mas_ids.stdout }}"
   register: osx_brew_bundle_host
-  changed_when: "'Installing' in osx_brew_bundle_host.stdout or 'Upgrading' in osx_brew_bundle_host.stdout"
+  changed_when: "'Upgrading' in osx_brew_bundle_host.stdout"
   tags: [upgrade]
 
 - name: Upgrade MAS apps


### PR DESCRIPTION
## Summary
- `mise run default` was failing in `brew bundle` whenever a mas app had a pending update and its `.app` in `/Applications` was owned by `root:wheel` (e.g. Fantastical, Spark Desktop). brew-bundle shells out to `sudo`, and Ansible has no TTY for the password prompt, so the whole playbook aborted.
- `roles/osx/tasks/homebrew.yml`: install path now uses `brew bundle install --no-upgrade`, so already-installed (even outdated) mas apps are a no-op. Also gives cleaner install-vs-upgrade semantics.
- `roles/osx/tasks/upgrade.yml`: new pre-task harvests `id: <n>` values from both Brewfiles and exports them via `HOMEBREW_BUNDLE_MAS_SKIP` around the two `brew bundle` upgrade calls. All mas handling is deferred to the existing `mas upgrade` step, which already has `failed_when: false` and so tolerates apps that still need sudo.

## Test plan
- [x] `mise run default` completes end-to-end (exit 0): install + upgrade + hooks:install
- [x] `yamllint` + `ansible-lint` clean on both changed files
- [x] Verified `brew bundle install --no-upgrade` shows `Using Fantastical` / `Using Spark` (no sudo prompt)
- [ ] Re-run on another host with pending mas updates to confirm upgrade path stays green