### PR TITLE
feat(ssh): match crojtini host alias by LAN IP too

### DIFF
--- a/roles/ssh/files/config
+++ b/roles/ssh/files/config
@@ -19,11 +19,13 @@ Host *
 Match host * exec "sh -c 'test -z \"$SSH_TTY\" && uname | grep -q Darwin && test -S ~/Library/Group\ Containers/2BUA8C4S2C.com.1password/t/agent.sock && (test -z \"$SSH_AUTH_SOCK\" || echo \"$SSH_AUTH_SOCK\" | grep -q \"com.apple.launchd\")'"
     IdentityAgent "~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
 
-Host crojtini
-    Hostname crojtini.local
+Host crojtini 192.168.1.100
     User inkatze
     ForwardAgent yes
     SendEnv ANTHROPIC_API_KEY
+
+Host crojtini
+    Hostname crojtini.local
 
 Host rfh.rsync.net
     Hostname usw-s004.rsync.net


### PR DESCRIPTION
## Summary
- Apply the `crojtini` SSH config (User, ForwardAgent, SendEnv) when connecting via either the `crojtini` alias or its LAN IP `192.168.1.100`.
- Keep the `Hostname crojtini.local` resolution scoped to the `crojtini` alias only, so direct IP connections still work without a redundant DNS lookup.

## Test plan
- [ ] `ssh crojtini` still resolves via `.local` and forwards the agent / sends `ANTHROPIC_API_KEY`.
- [ ] `ssh 192.168.1.100` connects as `inkatze` with agent forwarding and `SendEnv` applied.
- [ ] `ssh -G crojtini` and `ssh -G 192.168.1.100` show the expected `user`, `forwardagent`, `sendenv` values.