### PR TITLE
feat(claude): add /copilot-pairing and 3-pass review rigor

### DIFF
--- a/roles/osx/files/CLAUDE.md
+++ b/roles/osx/files/CLAUDE.md
@@ -118,7 +118,7 @@ For non-testable changes (docs, comments, formatting, pure renames, type-only ad
 There are four distinct review workflows, each with a corresponding slash command:
 
 1. **Self-review** (`/self-review`): Comprehensive code review of the feature branch against main. Review, validate for false positives, iterate until clean, then push and create a draft PR.
-2. **Copilot review** (`/copilot-review`): Address unresolved GitHub Copilot review threads on the current PR. Fetch threads via GraphQL, reproduce each issue when relevant, design our own fix (do not trust Copilot's recommendation), do a second-pass validation, present findings as a table, then implement test-first when applicable, comment, and resolve threads via GraphQL.
+2. **Copilot review** (`/copilot-review`): Address unresolved GitHub Copilot review threads on the current PR. Fetch threads via GraphQL, reproduce each issue when relevant, design our own fix (do not trust Copilot's recommendation), validate via the three-pass rigor, present findings as a table, then implement test-first when applicable, comment, and resolve threads via GraphQL.
 3. **Copilot pairing** (`/copilot-pairing`): Same rigor as `/copilot-review`, but loops autonomously: address Copilot's threads, push, re-request review, wait for Copilot's response, repeat until Copilot has no new comments. Hard stop conditions (ambiguity, scope creep, test failure, security-sensitive code, loop detection, iteration cap of 10) hand control back to the human.
 4. **Peer review** (`/peer-review`): Address unresolved peer review threads on the current PR. Same validation process as Copilot review, but responses must sound natural, human, and match the user's communication style.
 

--- a/roles/osx/files/CLAUDE.md
+++ b/roles/osx/files/CLAUDE.md
@@ -96,12 +96,31 @@ When reviewing code, features, or addressing PR feedback:
 - For each item in one-by-one mode: present it, discuss it, and wait for the user's decision before moving to the next.
 - This applies to: PR review comments, code review findings, feature review feedback, and any similar review workflow.
 
+### Validation Rigor (Issue Identification)
+
+For any review workflow that flags issues, do at least **three independent validation passes per finding**. Each pass must use a different method or perspective, not the same approach repeated. The goal is to expose blind spots that any single approach misses. If the three passes do not converge on the same conclusion, drop or downgrade the finding.
+
+- **Pass 1: direct reproduction.** When the claim concerns runtime behavior, reproduce it. Write a failing test, run the code, trace through with concrete inputs, or construct the exact failing scenario. Inability to reproduce is a strong signal the issue may not exist.
+- **Pass 2: orthogonal angle.** Use a different lens than pass 1. Examples: callers and upstream context, related code paths and side effects, project conventions and sibling implementations, existing test coverage that may already prove the case safe.
+- **Pass 3: outside-in angle.** Consult sources outside the diff. `git log` / `git blame` for the why-it-is-the-way-it-is. Repo-wide search for similar patterns. For text or research-based claims (API correctness, spec compliance, deprecated patterns, security claims, library behavior): official docs, the library's own source and tests, the deepwiki MCP for repo facts, GitHub issues, RFCs, web search. Note what was consulted in the finding.
+
+### Validation Rigor (Solutions)
+
+For any fix, validate the solution with at least two independent test angles, three when relevant:
+
+1. **Targeted test.** Write a test that fails on current code for the bug's exact reason. Confirm it fails for the right reason before applying the fix. Apply the fix. Confirm the test now passes.
+2. **Wider check.** Run the full project test suite, linters, and type-checkers. Watch for regressions, including in unrelated areas the change could now affect.
+3. **Edge / integration / manual.** When relevant: boundary cases (null, empty, max size, concurrency), integration or smoke tests, manual exercise of the user-facing flow.
+
+For non-testable changes (docs, comments, formatting, pure renames, type-only adjustments): substitute review angles. Re-read the diff, read it from the perspective of each caller, and grep the repo for places the change could silently break. Note in the reply why a test was not added.
+
 ### Review Workflows
-There are three distinct review workflows, each with a corresponding slash command:
+There are four distinct review workflows, each with a corresponding slash command:
 
 1. **Self-review** (`/self-review`): Comprehensive code review of the feature branch against main. Review, validate for false positives, iterate until clean, then push and create a draft PR.
-2. **Copilot review** (`/copilot-review`): Address unresolved GitHub Copilot review threads on the current PR. Fetch threads via GraphQL, validate each one (emphasis on catching false positives), address valid items, then comment and resolve threads via GraphQL.
-3. **Peer review** (`/peer-review`): Address unresolved peer review threads on the current PR. Same validation process as Copilot review, but responses must sound natural, human, and match the user's communication style.
+2. **Copilot review** (`/copilot-review`): Address unresolved GitHub Copilot review threads on the current PR. Fetch threads via GraphQL, reproduce each issue when relevant, design our own fix (do not trust Copilot's recommendation), do a second-pass validation, present findings as a table, then implement test-first when applicable, comment, and resolve threads via GraphQL.
+3. **Copilot pairing** (`/copilot-pairing`): Same rigor as `/copilot-review`, but loops autonomously: address Copilot's threads, push, re-request review, wait for Copilot's response, repeat until Copilot has no new comments. Hard stop conditions (ambiguity, scope creep, test failure, security-sensitive code, loop detection, iteration cap of 10) hand control back to the human.
+4. **Peer review** (`/peer-review`): Address unresolved peer review threads on the current PR. Same validation process as Copilot review, but responses must sound natural, human, and match the user's communication style.
 
 ## Writing Style
 - Avoid em-dashes in prose unless strictly necessary. Use commas, parentheses, colons, or separate sentences instead.

--- a/roles/osx/files/CLAUDE.md
+++ b/roles/osx/files/CLAUDE.md
@@ -122,6 +122,8 @@ There are four distinct review workflows, each with a corresponding slash comman
 3. **Copilot pairing** (`/copilot-pairing`): Same rigor as `/copilot-review`, but loops autonomously: address Copilot's threads, push, re-request review, wait for Copilot's response, repeat until Copilot has no new comments. Hard stop conditions (ambiguity, scope creep, test failure, security-sensitive code, loop detection, iteration cap of 10) hand control back to the human.
 4. **Peer review** (`/peer-review`): Address unresolved peer review threads on the current PR. Same validation process as Copilot review, but responses must sound natural, human, and match the user's communication style.
 
+For reviewing **someone else's** PR (not your own), use `/code-review` instead. It checks out the PR, applies the same three-pass validation rigor, and drafts comments for the user to submit manually.
+
 ## Writing Style
 - Avoid em-dashes in prose unless strictly necessary. Use commas, parentheses, colons, or separate sentences instead.
 

--- a/roles/osx/files/CLAUDE.md
+++ b/roles/osx/files/CLAUDE.md
@@ -83,13 +83,13 @@ When pushing:
 
 Plans are written with limited context and the codebase may have changed since. When transitioning from a plan to implementation:
 - **Plans are directional, not prescriptive**: Treat plans as a guide for intent and scope, not as step-by-step instructions to follow blindly
-- **Verify before acting**: Always read the actual code before making changes — don't assume the plan's description of file contents, function signatures, or structure is accurate
+- **Verify before acting**: Always read the actual code before making changes. Don't assume the plan's description of file contents, function signatures, or structure is accurate
 - **Adapt to reality**: If the code doesn't match what the plan expected, adjust your approach to fit the actual state of the codebase rather than forcing the plan's assumptions
 
 ## Code & PR Reviews
 
 When reviewing code, features, or addressing PR feedback:
-- **Verify issues are real**: Before reporting an issue, confirm it by reading the relevant code and running tests/linters if applicable. Do not report speculative or hypothetical issues — only confirmed ones.
+- **Verify issues are real**: Before reporting an issue, confirm it by reading the relevant code and running tests/linters if applicable. Do not report speculative or hypothetical issues, only confirmed ones.
 - **Present all issues first**: After analysis, present the complete list of confirmed issues as a numbered summary with brief descriptions.
 - **Let the user choose the workflow**: Ask whether they want to review items one by one or discuss the list as a whole (e.g., re-prioritize, dismiss items, group them). Do not assume they want all items addressed at once.
 - **Progress tracking**: When going one by one, always show a progress tracker (e.g., `[2/7]`) so the current position and total count are always visible.

--- a/roles/osx/files/claude/commands/code-review.md
+++ b/roles/osx/files/claude/commands/code-review.md
@@ -41,7 +41,7 @@ If the diff is large, review file-by-file using `git diff <base>...HEAD -- <path
 - Dead code or unnecessary changes
 - If a Jira ticket was found: whether the changes satisfy each acceptance criterion, and whether anything is missing or inconsistent with the ticket requirements
 
-### 6. Validate every finding — three passes minimum (different angle each)
+### 6. Validate every finding: three passes minimum (different angle each)
 
 Apply the canonical rigor in CLAUDE.md `Validation Rigor (Issue Identification)`. For each potential issue:
 
@@ -50,7 +50,7 @@ Apply the canonical rigor in CLAUDE.md `Validation Rigor (Issue Identification)`
 - **Pass 2: orthogonal angle.** A different lens: callers and what they assume, related code paths and side effects, project conventions, sibling implementations, existing test coverage.
 - **Pass 3: outside-in angle.** Sources outside the diff: `git log` / `git blame` for the why-it-is-the-way-it-is, repo-wide search for similar patterns, and for text/research-based claims (API correctness, spec compliance, deprecated patterns, security claims, library behavior) consult official docs, the library's own source/tests, deepwiki MCP, GitHub issues, RFCs, web search. Note what was checked.
 
-Drop or downgrade items where the three passes do not converge. We are leaving comments on someone else's PR — false positives have a higher cost here than in self-review.
+Drop or downgrade items where the three passes do not converge. We are leaving comments on someone else's PR, so false positives have a higher cost here than in self-review.
 
 ### 7. Present the validated list
 

--- a/roles/osx/files/claude/commands/code-review.md
+++ b/roles/osx/files/claude/commands/code-review.md
@@ -41,9 +41,16 @@ If the diff is large, review file-by-file using `git diff <base>...HEAD -- <path
 - Dead code or unnecessary changes
 - If a Jira ticket was found: whether the changes satisfy each acceptance criterion, and whether anything is missing or inconsistent with the ticket requirements
 
-### 6. Validate every finding
+### 6. Validate every finding — three passes minimum (different angle each)
 
-For each potential issue, read the full source file to understand context. Eliminate false positives and speculative concerns. Only report issues you are confident about.
+Apply the canonical rigor in CLAUDE.md `Validation Rigor (Issue Identification)`. For each potential issue:
+
+- **Read first.** The full source file to understand context, plus callers and related modules.
+- **Pass 1: direct reproduction.** When the issue concerns runtime behavior, reproduce it. Failing test, repro script, trace through the code with concrete inputs, or construct an input that triggers the bug. Inability to reproduce is a strong signal of a false positive.
+- **Pass 2: orthogonal angle.** A different lens: callers and what they assume, related code paths and side effects, project conventions, sibling implementations, existing test coverage.
+- **Pass 3: outside-in angle.** Sources outside the diff: `git log` / `git blame` for the why-it-is-the-way-it-is, repo-wide search for similar patterns, and for text/research-based claims (API correctness, spec compliance, deprecated patterns, security claims, library behavior) consult official docs, the library's own source/tests, deepwiki MCP, GitHub issues, RFCs, web search. Note what was checked.
+
+Drop or downgrade items where the three passes do not converge. We are leaving comments on someone else's PR — false positives have a higher cost here than in self-review.
 
 ### 7. Present the validated list
 
@@ -51,6 +58,7 @@ For each item, include:
 - File path and line number
 - Severity: **blocker**, **concern**, **suggestion**, or **nit**
 - A clear description of the issue
+- One-line note on which validation passes converged (e.g. "reproduced via failing test in pass 1, confirmed by sibling implementation in pass 2, library docs in pass 3")
 - A proposed inline comment draft
 
 If nothing substantive remains, say so.

--- a/roles/osx/files/claude/commands/copilot-pairing.md
+++ b/roles/osx/files/claude/commands/copilot-pairing.md
@@ -1,4 +1,4 @@
-Iterate with GitHub Copilot autonomously until it stops requesting changes on the current PR.
+Iterate with GitHub Copilot autonomously until it has no unresolved threads on the current PR. Copilot reviews land as `state: COMMENTED` (not `CHANGES_REQUESTED`), so the termination signal is "the latest Copilot review after our push leaves zero unresolved Copilot threads", not a state change.
 
 Same validation rigor as `/copilot-review`, executed on autopilot, with hard stop conditions baked in for safety.
 

--- a/roles/osx/files/claude/commands/copilot-pairing.md
+++ b/roles/osx/files/claude/commands/copilot-pairing.md
@@ -23,10 +23,7 @@ You want a hands-off pairing pass with Copilot. The skill loops: address Copilot
    ' -f owner='OWNER' -f repo='REPO' -F number=NUMBER
    ```
    Use the actual `Bot` login if it differs.
-4. **Snapshot baseline state**:
-   - Current HEAD SHA (`git rev-parse HEAD`).
-   - Set of currently-open Copilot thread IDs.
-   - Iteration counter = 0.
+4. **Initialize iteration counter** = 0. The loop's per-iteration filter is `isResolved: false` (step (a)), so we don't need to snapshot HEAD or the baseline thread-ID set.
 
 ## Iteration loop
 
@@ -65,23 +62,55 @@ For **false positives**, draft the dismissal reply (citing the three passes) but
 
 Run whatever the project ships for local verification: tests, linters, type checkers, formatters. Common entry points: `npm test`, `pytest`, `go test ./...`, `cargo test`, `bundle exec rspec`, `mise run test`, `lefthook run pre-commit`. If the project has a single canonical command, prefer it. If anything fails (even a pre-existing failure unrelated to our changes), trigger the **Test failure** stop condition.
 
-### e. Reply, resolve, commit, push
+### e. Commit, push, reply, resolve
 
-- Reply to and resolve every thread using `/copilot-review` step 8 mutations (multi-line GraphQL, body via temp file).
-- If this iteration produced **no code changes** (every thread was classified `already-handled` and we only re-fired the resolves), skip the commit / push and go to step (f.5) below: do not re-request review against an unchanged HEAD, since Copilot will not respond and step (g) will time out.
-- Otherwise: `git add` only the files we actually changed for this iteration (never `git add -A`). Commit with a message of the form `chore(copilot): iter N, address <short summary>`. Push: `git push origin <branch>`. **Never** `--force`, `--force-with-lease`, or any rebase flag.
-- Immediately after the push completes, capture the timestamp and persist it for step (g): `date -u +%Y-%m-%dT%H:%M:%SZ > /tmp/copilot-pairing-push-ts`. The Bash tool spawns a fresh shell per invocation, so a plain shell variable will not be visible to the step (g) script. Use the temp file, or inline the literal value into the step (g) script when you send it. This timestamp is the high-water mark used by step (g)'s poll filter; capturing it any earlier risks matching a Copilot review that pre-dates this iteration's push.
+Order matters: land the code first, then talk about it. If we replied/resolved before pushing and the push failed, threads would sit resolved without an actual fix landed and the next iteration would not see them as unresolved (silent loss of work).
 
-### f. Re-request Copilot review
+**Branch on whether this iteration produced code changes.**
 
-Trigger a new Copilot review by re-adding it to the requested reviewers list:
+**Path A — code changes were made (the common path):**
+
+1. **Commit and push.**
+   - `git add` only the files we actually changed for this iteration (never `git add -A`).
+   - Commit with a message of the form `chore(copilot): iter N, address <short summary>`.
+   - Push: `git push origin <branch>`. **Never** `--force`, `--force-with-lease`, or any rebase flag.
+2. **Capture push timestamp.** Immediately after push completes:
+   ```bash
+   date -u +%Y-%m-%dT%H:%M:%SZ > /tmp/copilot-pairing-push-ts
+   ```
+   The Bash tool spawns a fresh shell per invocation, so a plain shell variable will not be visible to the step (g) script. Use the temp file, or inline the literal value into the step (g) script when you send it. This timestamp is the high-water mark for step (g)'s poll filter; capturing it any earlier risks matching a Copilot review that pre-dates this push.
+3. **Reply to threads** using `/copilot-review` step 8 mutations (multi-line GraphQL, body via temp file). **Use `addPullRequestReviewThreadReply` only** — see the DO-NOT-USE callout in `/copilot-review` step 8 about `addPullRequestReviewComment`.
+4. **Resolve threads** using `/copilot-review` step 8's `resolveReviewThread` mutation.
+5. Proceed to step (f).
+
+**Path B — no code changes (every thread was `already-handled`):**
+
+1. Skip commit/push and skip the push-timestamp capture (no new HEAD; step (g) is skipped on this path).
+2. Reply to each thread with a short body referencing the prior commit that actually addressed it (find the commit via `git log --oneline -- <file>` for the relevant file). Use `addPullRequestReviewThreadReply` (same DO-NOT-USE callout applies).
+3. Resolve threads via `resolveReviewThread`.
+4. Proceed to step (f.5), not (f): do not re-request review against an unchanged HEAD, since Copilot will not respond and step (g) will time out.
+
+### f. Re-request Copilot review (best-effort)
+
+Try to trigger a new Copilot review by re-adding it to the requested reviewers list:
 
 ```bash
 gh api -X POST "repos/OWNER/REPO/pulls/NUMBER/requested_reviewers" \
   -f 'reviewers[]=copilot-pull-request-reviewer'
 ```
 
-If the request returns 422 because Copilot is already a requested reviewer, remove it then re-run the POST:
+This call is **best-effort**, not load-bearing. The actual signal the loop relies on is step (g)'s GraphQL poll for a new review. Repos where Copilot is installed as a GitHub App typically auto-review on push, so an explicit re-request is unnecessary (and the REST endpoint will reject it).
+
+Inspect the response and branch:
+
+| Outcome | Body contains | Action |
+|---|---|---|
+| 2xx | — | Proceed to step (g). |
+| 422 | `already requested` (or similar "duplicate reviewer") | DELETE the reviewer, re-POST. Then proceed to step (g). |
+| 422 | `not a collaborator` (or any other 422) | Log a single-line warning that the explicit re-request was rejected (likely auto-review-on-push repo). Proceed to step (g). |
+| Other (4xx/5xx) | — | Log warning. Proceed to step (g). |
+
+DELETE+POST retry pattern (only for the `already requested` case):
 
 ```bash
 gh api -X DELETE "repos/OWNER/REPO/pulls/NUMBER/requested_reviewers" \
@@ -91,7 +120,7 @@ gh api -X POST "repos/OWNER/REPO/pulls/NUMBER/requested_reviewers" \
   -f 'reviewers[]=copilot-pull-request-reviewer'
 ```
 
-**First-run verification.** This re-request path has not been live-tested for every account / repo combination. On iteration 1, after firing the POST, confirm: (a) the call returned 2xx, and (b) Copilot actually starts a new review (visible in step (g)'s poll). If either fails, trigger the **No response** stop condition and hand back to me; do not blindly continue looping.
+Do NOT trigger the **No response** stop condition based on this step's HTTP outcome. **No response** is reserved for step (g)'s 10-minute poll timing out — that is the only authoritative signal that Copilot did not review.
 
 ### f.5. Resolve-only iteration short-circuit
 
@@ -137,11 +166,25 @@ echo "TIMEOUT"; exit 1
 
 **Alternative**: `Monitor` the same script with an until-loop if you want streaming progress lines.
 
-After the script reports `NEW_REVIEW`, re-fetch reviewThreads and compare against the baseline:
-- **Zero new unresolved Copilot threads**: success. Exit the loop.
-- **One or more new threads**: increment iteration counter and loop back to (a).
+Branch on the script's exit:
 
-If the script reports `TIMEOUT`, trigger the **No response** stop condition.
+- **Exit 0 (`NEW_REVIEW`)**: re-fetch reviewThreads. If any are unresolved, increment iteration counter and loop back to (a). If zero unresolved, success — exit the loop.
+- **Exit 1 (`TIMEOUT`)**: trigger the **No response** stop condition.
+- **Exit 2 (bad input)**: step (e) failed to capture `push_ts`. Bug in our flow. Stop and surface the script's stderr.
+- **Any other exit code (e.g. 144 from external SIGTERM, OOM kill, harness session end)**: the script was killed externally; its output is not authoritative. Re-query GraphQL directly using the `push_ts` from `/tmp/copilot-pairing-push-ts`:
+  ```bash
+  push_ts=$(cat /tmp/copilot-pairing-push-ts)
+  gh api graphql -f query='...same as the poll script...' \
+    -f owner='OWNER' -f repo='REPO' -F number=NUMBER \
+    | jq --arg bot 'copilot-pull-request-reviewer' --arg ts "$push_ts" '
+        .data.repository.pullRequest.reviews.nodes
+        | map(select(.author.login == $bot and .submittedAt > $ts))'
+  ```
+  - **New Copilot review found**: treat as `NEW_REVIEW` and proceed as above.
+  - **No new review, still inside the 10-minute window** (compare `push_ts + 600s` to current `date +%s`): restart the background poll script. Cap restarts at **2** per iteration to prevent thrashing — after that, treat as **No response**.
+  - **No new review, past deadline**: treat as `TIMEOUT` and trigger **No response**.
+
+Never assume "loop succeeded" from a non-zero, non-1 exit code. Always cross-check via GraphQL.
 
 ### h. Iteration summary
 

--- a/roles/osx/files/claude/commands/copilot-pairing.md
+++ b/roles/osx/files/claude/commands/copilot-pairing.md
@@ -31,6 +31,8 @@ You want a hands-off pairing pass with Copilot. The skill loops: address Copilot
 
 For each iteration (cap = **10**):
 
+**Cap check (run at the start of every iteration, before step (a)).** Read the iteration counter (initialized to 0 in pre-flight step 4; incremented in step (g) on `NEW_REVIEW` and in step (f.5) on "one or more remaining"). If the counter has reached **10**, do not enter step (a). Trigger the **Iteration cap** stop condition and hand control back. This is the only place the cap is enforced; the counter increments in (g) and (f.5) do not enforce it themselves.
+
 ### a. Fetch Copilot's open threads
 
 Use the same GraphQL query as `/copilot-review` step 3. Filter to threads where `isResolved: false` AND first comment author login == Copilot bot login. Do not add a "skip if older than last push" filter: `isResolved: false` is the canonical signal, and a previous iteration's resolve mutation may have failed silently; this loop should retry it, not skip it.
@@ -84,7 +86,10 @@ Order matters: land the code first, then talk about it. If we replied/resolved b
    date +%s > /tmp/copilot-pairing-push-epoch.NUMBER
    ```
    The Bash tool spawns a fresh shell per invocation, so a plain shell variable will not be visible to the step (g) script. Use the temp file, or inline the literal value into the step (g) script when you send it. The filename is namespaced by PR number so concurrent pairing sessions on different PRs (e.g., separate worktrees) do not clobber each other's timestamps. We use epoch (not ISO-8601) so the poll filter can compare numerically via `fromdateiso8601` and avoid lexicographic edge cases at sub-second precision. This high-water mark is the floor for step (g)'s poll filter; capturing it any earlier risks matching a Copilot review that pre-dates this push.
-3. **Reply to threads** using `/copilot-review` step 8 mutations (multi-line GraphQL, body via temp file). **Use `addPullRequestReviewThreadReply` only**; see the DO-NOT-USE callout in `/copilot-review` step 8 about `addPullRequestReviewComment`.
+3. **Reply to threads** using `/copilot-review` step 8 mutations (multi-line GraphQL, body via temp file). **Use `addPullRequestReviewThreadReply` only**; see the DO-NOT-USE callout in `/copilot-review` step 8 about `addPullRequestReviewComment`. Reply body varies by classification, since this iteration may have a mix:
+   - **`valid`**: short reply describing the change we made, ideally referencing the new commit SHA from (e.1).
+   - **`already-handled`**: reply with `addressed in <commit-sha>` per Path B step 2, using the same `git log "$(gh pr view --json baseRefName -q '.baseRefName')..HEAD" --oneline -- <file>` lookup. Do not hardcode `main` as the base.
+   - **`false positive`**: post the dismissal reply drafted in step (b) (citing the three passes and why the concern does not apply).
 4. **Submit any auto-vivified pending review (mandatory).** `addPullRequestReviewThreadReply` can create a new pending review owned by the viewer when none is in progress; the replies posted in (e.3) then stay invisible (to GitHub UI, to Copilot, to humans) until that review is submitted. See `/copilot-review` step 8's "Submit any auto-vivified pending review" sub-step for the exact GraphQL. Procedure: query the PR's `reviews(states: PENDING)` filtered by `author.login == viewer.login`; for each, call `submitPullRequestReview(id, event: COMMENT)`. Re-query and assert zero pending reviews owned by the viewer remain before proceeding to step (e.5). If a pending review cannot be submitted, stop with the **Pending reply unsubmittable** condition.
 5. **Resolve threads** using `/copilot-review` step 8's `resolveReviewThread` mutation.
 6. Proceed to step (f).

--- a/roles/osx/files/claude/commands/copilot-pairing.md
+++ b/roles/osx/files/claude/commands/copilot-pairing.md
@@ -82,27 +82,55 @@ Order matters: land the code first, then talk about it. If we replied/resolved b
    ```
    The Bash tool spawns a fresh shell per invocation, so a plain shell variable will not be visible to the step (g) script. Use the temp file, or inline the literal value into the step (g) script when you send it. The filename is namespaced by PR number so concurrent pairing sessions on different PRs (e.g., separate worktrees) do not clobber each other's timestamp. This timestamp is the high-water mark for step (g)'s poll filter; capturing it any earlier risks matching a Copilot review that pre-dates this push.
 3. **Reply to threads** using `/copilot-review` step 8 mutations (multi-line GraphQL, body via temp file). **Use `addPullRequestReviewThreadReply` only**; see the DO-NOT-USE callout in `/copilot-review` step 8 about `addPullRequestReviewComment`.
-4. **Resolve threads** using `/copilot-review` step 8's `resolveReviewThread` mutation.
-5. Proceed to step (f).
+4. **Submit any auto-vivified pending review (mandatory).** `addPullRequestReviewThreadReply` can create a new pending review owned by the viewer when none is in progress; the replies posted in (e.3) then stay invisible (to GitHub UI, to Copilot, to humans) until that review is submitted. See `/copilot-review` step 8's "Submit any auto-vivified pending review" sub-step for the exact GraphQL. Procedure: query the PR's `reviews(states: PENDING)` filtered by `author.login == viewer.login`; for each, call `submitPullRequestReview(id, event: COMMENT)`. Re-query and assert zero pending reviews owned by the viewer remain before proceeding to step (e.5). If a pending review cannot be submitted, stop with the **Pending reply unsubmittable** condition.
+5. **Resolve threads** using `/copilot-review` step 8's `resolveReviewThread` mutation.
+6. Proceed to step (f).
 
 **Path B (no code changes, every thread was `already-handled`):**
 
 1. Skip commit/push and skip the push-timestamp capture (no new HEAD; step (g) is skipped on this path).
 2. Reply to each thread with a short body referencing the prior commit that actually addressed it. Find the commit via `git log "$(gh pr view --json baseRefName -q '.baseRefName')..HEAD" --oneline -- <file>` (scoped to this branch's commits, top entry is the most recent). Do not hardcode `main`: PRs targeting `develop`, `release/*`, or any other base branch would otherwise return wrong or empty commits. Use `addPullRequestReviewThreadReply` (same DO-NOT-USE callout applies).
-3. Resolve threads via `resolveReviewThread`.
-4. Proceed to step (f.5), not (f): do not re-request review against an unchanged HEAD, since Copilot will not respond and step (g) will time out.
+3. **Submit any auto-vivified pending review (mandatory).** Same procedure as Path A step 4. The auto-vivify failure mode applies here too because we still call `addPullRequestReviewThreadReply`.
+4. Resolve threads via `resolveReviewThread`.
+5. Proceed to step (f.5), not (f): do not re-request review against an unchanged HEAD, since Copilot will not respond and step (g) will time out.
 
-### f. Re-request Copilot review (best-effort, mode-aware)
+### f. Re-request Copilot review (mode-aware, verify-loud)
 
 Branch on `repo_mode` from pre-flight step 3.
 
-**`app` mode (`__typename == "Bot"` in pre-flight):** skip the POST entirely. Auto-review on push handles the trigger. Log a single line for the iteration summary:
+**`app` mode (`__typename == "Bot"` in pre-flight):** auto-review on push is **not** guaranteed. Verified failure mode (2026-05-02 live run on `SymmetrySoftware/stl-poc#13`): push completed, `reviewRequests.nodes` came back empty, no auto-review fired, and step (g) would have timed out silently after 10 minutes. Do not skip the request.
+
+Explicitly request Copilot via the GitHub MCP tool:
 
 ```
-App-mode repo, auto-review on push will trigger Copilot. Skipping explicit re-request.
+mcp__<github-server>__request_copilot_review
+params: { owner, repo, pullNumber }
 ```
 
-Then proceed to step (g). **Step (g) is mandatory in App mode.** Auto-review-on-push triggers Copilot, but only step (g)'s poll confirms it actually reviewed. Skipping (g) on the assumption that "push = review" is the regression this branch's wording was written to prevent.
+The substitute for `<github-server>` depends on the active MCP server (e.g. `claude_ai_Github-Symmetry`, `claude_ai_Github-Gusto`). The REST endpoint `POST /repos/{owner}/{repo}/pulls/{n}/requested_reviewers` returns 422 "not a collaborator" for Bot reviewers and must NOT be used in app mode; the MCP tool wraps an internal Copilot-review-request endpoint that accepts Bot reviewers. If no `request_copilot_review` MCP tool is available on the active server, stop with **No response** and report; do not assume push alone will trigger a review.
+
+After the MCP call returns success, **verify** Copilot is actually on the requested-reviewer list:
+
+```bash
+gh api graphql -f query='
+  query($owner: String!, $repo: String!, $number: Int!) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $number) {
+        reviewRequests(first: 10) {
+          nodes {
+            requestedReviewer {
+              ... on Bot { login }
+              ... on User { login }
+            }
+          }
+        }
+      }
+    }
+  }
+' -f owner='OWNER' -f repo='REPO' -F number=NUMBER
+```
+
+If the verified Copilot bot login (from pre-flight step 3) is in `reviewRequests.nodes`, proceed to step (g). If not, log a warning ("MCP request_copilot_review returned success but reviewRequests does not include the bot") and proceed to step (g) anyway: the poll is the authoritative confirmation. **Step (g) is mandatory in app mode.** Skipping it on the assumption that the request "must have worked" is the regression earlier wording was written to prevent.
 
 **`collaborator` mode:** try to trigger a new Copilot review by re-adding it to the requested reviewers list. Substitute the verified bot login from pre-flight step 3 if it differs from the default.
 
@@ -229,6 +257,7 @@ If any condition fires, **stop**. Print the latest iteration table, name the con
 | **Cannot reproduce** | Issue is not reproducible and the proposed fix is non-trivial. |
 | **Migrations / data / destructive ops** | Schema migrations, data backfills, deletes, drops, or anything irreversible. Always human-driven. |
 | **No response** | 10-minute poll window expires with no new Copilot review. |
+| **Pending reply unsubmittable** | A pending review owned by the viewer cannot be submitted via `submitPullRequestReview` in step (e.4), so replies posted in (e.3) would remain invisible to GitHub, Copilot, and humans. |
 | **Conflicting signals** | Copilot's later review contradicts an earlier one we already addressed. Pause to decide which to honor. |
 
 ## Auto-execution invariants
@@ -242,6 +271,8 @@ These hold at every step:
 - **Never** modify CI configuration, `.env`, secrets, or lockfiles unless the Copilot thread is specifically about that file.
 - **Never** post anything to chat platforms or tickets.
 - **Never** skip step (g) after a Path-A push. The 10-minute poll is the only authoritative signal that Copilot has (or has not) reviewed. App-mode auto-review, step (f)'s HTTP outcome, prior iterations' patterns, and elapsed iteration count are not substitutes. Confirmation bias from a long successful run is the failure mode this invariant catches.
+- **Never** leave replies in a pending review. `addPullRequestReviewThreadReply` may auto-vivify a pending review owned by the viewer when none is in progress; step (e.4) submits it before resolving threads. A run that completes with replies still pending is a silent failure: GitHub, Copilot, and humans see no replies, and the next iteration polls Copilot reviewing against a state where it has no record of our responses (confirmation-bias path: looks fine, isn't).
+- **Never** trust an external-effect step's happy-path response without re-querying state. After step (f)'s `request_copilot_review` MCP call, verify the bot is on `reviewRequests.nodes`; after step (e.3)'s reply mutation, verify zero pending reviews owned by the viewer remain. Both bugs that motivated this section's wording (2026-05-02 live run on `SymmetrySoftware/stl-poc#13`) returned success and looked fine.
 
 ## Maintenance
 

--- a/roles/osx/files/claude/commands/copilot-pairing.md
+++ b/roles/osx/files/claude/commands/copilot-pairing.md
@@ -68,7 +68,7 @@ Order matters: land the code first, then talk about it. If we replied/resolved b
 
 **Branch on whether this iteration produced code changes.**
 
-**Path A — code changes were made (the common path):**
+**Path A (code changes were made, the common path):**
 
 1. **Commit and push.**
    - `git add` only the files we actually changed for this iteration (never `git add -A`).
@@ -79,14 +79,14 @@ Order matters: land the code first, then talk about it. If we replied/resolved b
    date -u +%Y-%m-%dT%H:%M:%SZ > /tmp/copilot-pairing-push-ts
    ```
    The Bash tool spawns a fresh shell per invocation, so a plain shell variable will not be visible to the step (g) script. Use the temp file, or inline the literal value into the step (g) script when you send it. This timestamp is the high-water mark for step (g)'s poll filter; capturing it any earlier risks matching a Copilot review that pre-dates this push.
-3. **Reply to threads** using `/copilot-review` step 8 mutations (multi-line GraphQL, body via temp file). **Use `addPullRequestReviewThreadReply` only** — see the DO-NOT-USE callout in `/copilot-review` step 8 about `addPullRequestReviewComment`.
+3. **Reply to threads** using `/copilot-review` step 8 mutations (multi-line GraphQL, body via temp file). **Use `addPullRequestReviewThreadReply` only**; see the DO-NOT-USE callout in `/copilot-review` step 8 about `addPullRequestReviewComment`.
 4. **Resolve threads** using `/copilot-review` step 8's `resolveReviewThread` mutation.
 5. Proceed to step (f).
 
-**Path B — no code changes (every thread was `already-handled`):**
+**Path B (no code changes, every thread was `already-handled`):**
 
 1. Skip commit/push and skip the push-timestamp capture (no new HEAD; step (g) is skipped on this path).
-2. Reply to each thread with a short body referencing the prior commit that actually addressed it (find the commit via `git log --oneline -- <file>` for the relevant file). Use `addPullRequestReviewThreadReply` (same DO-NOT-USE callout applies).
+2. Reply to each thread with a short body referencing the prior commit that actually addressed it. Find the commit via `git log main..HEAD --oneline -- <file>` (scoped to this branch's commits, top entry is the most recent). Use `addPullRequestReviewThreadReply` (same DO-NOT-USE callout applies).
 3. Resolve threads via `resolveReviewThread`.
 4. Proceed to step (f.5), not (f): do not re-request review against an unchanged HEAD, since Copilot will not respond and step (g) will time out.
 
@@ -120,7 +120,7 @@ gh api -X POST "repos/OWNER/REPO/pulls/NUMBER/requested_reviewers" \
   -f 'reviewers[]=copilot-pull-request-reviewer'
 ```
 
-Do NOT trigger the **No response** stop condition based on this step's HTTP outcome. **No response** is reserved for step (g)'s 10-minute poll timing out — that is the only authoritative signal that Copilot did not review.
+Do NOT trigger the **No response** stop condition based on this step's HTTP outcome. **No response** is reserved for step (g)'s 10-minute poll timing out, the only authoritative signal that Copilot did not review.
 
 ### f.5. Resolve-only iteration short-circuit
 
@@ -168,7 +168,7 @@ echo "TIMEOUT"; exit 1
 
 Branch on the script's exit:
 
-- **Exit 0 (`NEW_REVIEW`)**: re-fetch reviewThreads. If any are unresolved, increment iteration counter and loop back to (a). If zero unresolved, success — exit the loop.
+- **Exit 0 (`NEW_REVIEW`)**: re-fetch reviewThreads. If any are unresolved, increment iteration counter and loop back to (a). If zero unresolved, success: exit the loop.
 - **Exit 1 (`TIMEOUT`)**: trigger the **No response** stop condition.
 - **Exit 2 (bad input)**: step (e) failed to capture `push_ts`. Bug in our flow. Stop and surface the script's stderr.
 - **Any other exit code (e.g. 144 from external SIGTERM, OOM kill, harness session end)**: the script was killed externally; its output is not authoritative. Re-query GraphQL directly using the `push_ts` from `/tmp/copilot-pairing-push-ts`:
@@ -181,7 +181,7 @@ Branch on the script's exit:
         | map(select(.author.login == $bot and .submittedAt > $ts))'
   ```
   - **New Copilot review found**: treat as `NEW_REVIEW` and proceed as above.
-  - **No new review, still inside the 10-minute window** (compare `push_ts + 600s` to current `date +%s`): restart the background poll script. Cap restarts at **2** per iteration to prevent thrashing — after that, treat as **No response**.
+  - **No new review, still inside the 10-minute window** (compare `push_ts + 600s` to current `date +%s`): restart the background poll script. Cap restarts at **2** per iteration to prevent thrashing; after that, treat as **No response**.
   - **No new review, past deadline**: treat as `TIMEOUT` and trigger **No response**.
 
 Never assume "loop succeeded" from a non-zero, non-1 exit code. Always cross-check via GraphQL.

--- a/roles/osx/files/claude/commands/copilot-pairing.md
+++ b/roles/osx/files/claude/commands/copilot-pairing.md
@@ -37,6 +37,8 @@ Use the same GraphQL query as `/copilot-review` step 3. Filter to threads where 
 
 **Pre-check for already-handled threads.** Before running the validation passes, read the referenced file and decide whether the code already implements what Copilot asked for (because a prior iteration applied the fix but the resolve mutation never landed). If yes, classify the thread as `already-handled`, skip steps (b) and (c) for it, and let step (e) post a brief reply ("addressed in <commit-sha>") and re-fire the resolve mutation. This is what keeps a benign retry from tripping the **Cannot reproduce** stop condition in step (b)'s Pass 1.
 
+**Guardrail.** A misjudged `already-handled` posts a misleading "addressed in <sha>" reply and resolves a thread that should not be resolved, and the rigor that would catch the misjudgement (step (b)) is the very rigor we just skipped. To classify as `already-handled`, you must (1) point to the specific commit on this branch that applied the fix (find via `git log "$(gh pr view --json baseRefName -q '.baseRefName')..HEAD" --oneline -- <file>`), and (2) confirm the current code on that file:line behaviorally matches Copilot's ask, not just looks superficially similar. If either step is uncertain, do **not** classify as `already-handled`; let the thread go through the full three-pass validation in step (b). False negatives are cheap (one extra validation pass); false positives are silent and corrupt the loop.
+
 ### b. Validate every thread (strict, three passes minimum)
 
 Apply `/copilot-review` step 4 in full: the canonical three-pass rigor in CLAUDE.md `Validation Rigor (Issue Identification)`. Pass 1 reproduces, pass 2 takes an orthogonal angle, pass 3 consults outside-the-diff sources (git history, repo-wide search, official docs, library source/tests, deepwiki MCP, GitHub issues, RFCs, web search for text/research-based claims).
@@ -76,11 +78,12 @@ Order matters: land the code first, then talk about it. If we replied/resolved b
    - `git add` only the files we actually changed for this iteration (never `git add -A`).
    - Commit with a message of the form `chore(copilot): iter N, address <short summary>`.
    - Push: `git push origin <branch>`. **Never** `--force`, `--force-with-lease`, or any rebase flag.
-2. **Capture push timestamp.** Immediately after push completes (substitute the PR number from pre-flight step 1):
+2. **Capture push timestamp** in two forms, ISO-8601 for the GraphQL string compare and Unix epoch for deadline math (substitute the PR number from pre-flight step 1):
    ```bash
    date -u +%Y-%m-%dT%H:%M:%SZ > /tmp/copilot-pairing-push-ts.NUMBER
+   date +%s                    > /tmp/copilot-pairing-push-epoch.NUMBER
    ```
-   The Bash tool spawns a fresh shell per invocation, so a plain shell variable will not be visible to the step (g) script. Use the temp file, or inline the literal value into the step (g) script when you send it. The filename is namespaced by PR number so concurrent pairing sessions on different PRs (e.g., separate worktrees) do not clobber each other's timestamp. This timestamp is the high-water mark for step (g)'s poll filter; capturing it any earlier risks matching a Copilot review that pre-dates this push.
+   The Bash tool spawns a fresh shell per invocation, so a plain shell variable will not be visible to the step (g) script. Use the temp files, or inline the literal values into the step (g) script when you send it. The filenames are namespaced by PR number so concurrent pairing sessions on different PRs (e.g., separate worktrees) do not clobber each other's timestamps. Capture both timestamps in the same `Bash` call so they cannot drift from each other. This high-water mark is the floor for step (g)'s poll filter; capturing it any earlier risks matching a Copilot review that pre-dates this push.
 3. **Reply to threads** using `/copilot-review` step 8 mutations (multi-line GraphQL, body via temp file). **Use `addPullRequestReviewThreadReply` only**; see the DO-NOT-USE callout in `/copilot-review` step 8 about `addPullRequestReviewComment`.
 4. **Submit any auto-vivified pending review (mandatory).** `addPullRequestReviewThreadReply` can create a new pending review owned by the viewer when none is in progress; the replies posted in (e.3) then stay invisible (to GitHub UI, to Copilot, to humans) until that review is submitted. See `/copilot-review` step 8's "Submit any auto-vivified pending review" sub-step for the exact GraphQL. Procedure: query the PR's `reviews(states: PENDING)` filtered by `author.login == viewer.login`; for each, call `submitPullRequestReview(id, event: COMMENT)`. Re-query and assert zero pending reviews owned by the viewer remain before proceeding to step (e.5). If a pending review cannot be submitted, stop with the **Pending reply unsubmittable** condition.
 5. **Resolve threads** using `/copilot-review` step 8's `resolveReviewThread` mutation.
@@ -180,13 +183,14 @@ We need to wait up to **10 minutes** for a new Copilot review. Do not foreground
 **Preferred: a single backgrounded poll script** (`Bash` with `run_in_background=true`). The script polls itself and exits when the condition is met or the deadline passes. You'll be notified when it exits. Substitute the verified bot login from pre-flight step 3 in the `--arg bot ...` flag if it differs from the default.
 
 ```bash
-# Read push_ts from the temp file written in step (e). Bash tool calls do not
-# share shell state, so reading from the file (or inlining the literal value
-# before sending the script) is required. The file is namespaced by PR number;
-# substitute NUMBER from pre-flight step 1.
+# Read push_ts and push_epoch from the temp files written in step (e). Bash
+# tool calls do not share shell state, so reading from the files (or inlining
+# the literal values before sending the script) is required. Files are
+# namespaced by PR number; substitute NUMBER from pre-flight step 1.
 push_ts=$(cat /tmp/copilot-pairing-push-ts.NUMBER 2>/dev/null)
-[ -n "$push_ts" ] || { echo "push_ts not set; capture it in step (e) before running"; exit 2; }
-deadline=$(( $(date +%s) + 600 ))
+push_epoch=$(cat /tmp/copilot-pairing-push-epoch.NUMBER 2>/dev/null)
+[ -n "$push_ts" ] && [ -n "$push_epoch" ] || { echo "push_ts/push_epoch not set; capture them in step (e) before running"; exit 2; }
+deadline=$(( push_epoch + 600 ))
 while [ $(date +%s) -lt $deadline ]; do
   latest=$(gh api graphql -f query='
     query($owner: String!, $repo: String!, $number: Int!) {
@@ -213,10 +217,11 @@ Branch on the script's exit:
 
 - **Exit 0 (`NEW_REVIEW`)**: re-fetch reviewThreads. If any are unresolved, increment iteration counter and loop back to (a). If zero unresolved, success: exit the loop.
 - **Exit 1 (`TIMEOUT`)**: trigger the **No response** stop condition.
-- **Exit 2 (bad input)**: step (e) failed to capture `push_ts`. Bug in our flow. Stop and surface the script's stderr.
-- **Any other exit code (e.g. 143 from SIGTERM, 137 from SIGKILL/OOM, or any 128+N signal exit from a harness session end)**: the script was killed externally; its output is not authoritative. Re-query GraphQL directly using the `push_ts` from `/tmp/copilot-pairing-push-ts.NUMBER`:
+- **Exit 2 (bad input)**: step (e) failed to capture `push_ts` or `push_epoch`. Bug in our flow. Stop and surface the script's stderr.
+- **Any other exit code (e.g. 143 from SIGTERM, 137 from SIGKILL/OOM, or any 128+N signal exit from a harness session end)**: the script was killed externally; its output is not authoritative. Re-query GraphQL directly using the `push_ts` from `/tmp/copilot-pairing-push-ts.NUMBER`, and read `push_epoch` from `/tmp/copilot-pairing-push-epoch.NUMBER` for the deadline check:
   ```bash
   push_ts=$(cat /tmp/copilot-pairing-push-ts.NUMBER)
+  push_epoch=$(cat /tmp/copilot-pairing-push-epoch.NUMBER)
   gh api graphql -f query='...same as the poll script...' \
     -f owner='OWNER' -f repo='REPO' -F number=NUMBER \
     | jq --arg bot 'copilot-pull-request-reviewer' --arg ts "$push_ts" '
@@ -224,7 +229,7 @@ Branch on the script's exit:
         | map(select(.author.login == $bot and .submittedAt > $ts))'
   ```
   - **New Copilot review found**: treat as `NEW_REVIEW` and proceed as above.
-  - **No new review, still inside the 10-minute window** (compare `push_ts + 600s` to current `date +%s`): restart the background poll script. Cap restarts at **2** per iteration to prevent thrashing; after that, treat as **No response**.
+  - **No new review, still inside the 10-minute window** (`[ $(date +%s) -lt $((push_epoch + 600)) ]`): restart the background poll script. Cap restarts at **2** per iteration to prevent thrashing; after that, treat as **No response**.
   - **No new review, past deadline**: treat as `TIMEOUT` and trigger **No response**.
 
 Never assume "loop succeeded" from a non-zero, non-1 exit code. Always cross-check via GraphQL.

--- a/roles/osx/files/claude/commands/copilot-pairing.md
+++ b/roles/osx/files/claude/commands/copilot-pairing.md
@@ -1,0 +1,159 @@
+Iterate with GitHub Copilot autonomously until it stops requesting changes on the current PR.
+
+Same validation rigor as `/copilot-review`, executed on autopilot, with hard stop conditions baked in for safety.
+
+## When to use
+
+You want a hands-off pairing pass with Copilot. The skill loops: address Copilot's threads, push, re-request review, wait, repeat. It pauses for human input the moment anything is ambiguous, looping, expanding scope, or breaking tests.
+
+## Pre-flight (once per run)
+
+1. **Get PR / repo info** (same as `/copilot-review` step 1).
+2. **(Optional) Jira context** (same as `/copilot-review` step 2).
+3. **Confirm the Copilot bot login.** Default is `copilot-pull-request-reviewer`. Verify by inspecting an existing review on the PR:
+   ```bash
+   gh api graphql -f query='
+     query($owner: String!, $repo: String!, $number: Int!) {
+       repository(owner: $owner, name: $repo) {
+         pullRequest(number: $number) {
+           reviews(first: 5) { nodes { author { __typename login } } }
+         }
+       }
+     }
+   ' -f owner='OWNER' -f repo='REPO' -F number=NUMBER
+   ```
+   Use the actual `Bot` login if it differs.
+4. **Snapshot baseline state**:
+   - Current HEAD SHA (`git rev-parse HEAD`).
+   - Set of currently-open Copilot thread IDs.
+   - Iteration counter = 0.
+
+## Iteration loop
+
+For each iteration (cap = **10**):
+
+### a. Fetch Copilot's open threads
+
+Use the same GraphQL query as `/copilot-review` step 3. Filter to threads where `isResolved: false` AND first comment author login == Copilot bot login. If a thread's first comment was created before the last commit SHA we pushed, skip it (it predates the latest review and may be stale).
+
+### b. Validate every thread (strict, three passes minimum)
+
+Apply `/copilot-review` step 4 in full: the canonical three-pass rigor in CLAUDE.md `Validation Rigor (Issue Identification)`. Pass 1 reproduces, pass 2 takes an orthogonal angle, pass 3 consults outside-the-diff sources (git history, repo-wide search, official docs, library source/tests, deepwiki MCP, GitHub issues, RFCs, web search for text/research-based claims).
+
+Be more conservative than in `/copilot-review` because nobody is checking our work in real time:
+
+- If the three passes do not converge, mark `low-confidence` and trigger the **Cannot reproduce** or **Ambiguity** stop condition (whichever fits).
+- If two valid interpretations exist, trigger **Ambiguity**.
+- If the fix would touch a file outside the PR's existing diff, trigger **Scope creep**.
+- Apply the same three-pass rigor to every proposed fix. Do not trust Copilot's recommendation; design our own from first principles, then validate it from three angles before accepting.
+
+### c. Implement valid items — solution validated with two or three test angles
+
+Apply `/copilot-review` step 6 (canonical rigor in CLAUDE.md `Validation Rigor (Solutions)`):
+
+1. **Targeted test.** Write a failing test for the bug's exact reason, confirm it fails for the right reason, apply the fix, confirm it now passes.
+2. **Wider check.** Run the broader project test suite, linters, type-checkers. Any regression — even in unrelated areas — triggers the **Test failure** stop condition.
+3. **Edge / integration / manual** (when relevant). Boundary cases, integration or smoke tests, manual exercise of the user-facing flow.
+
+Skip the targeted-test step only for non-behavioral changes (docs, comments, pure renames, formatting). For those, substitute review angles per the canonical doctrine.
+
+For **false positives**, draft the dismissal reply (citing the three passes) but do NOT post yet. We post all replies in step (e) after the build is green.
+
+### d. Run the full local check suite
+
+Run whatever the project ships for local verification: tests, linters, type checkers, formatters. Common entry points: `npm test`, `pytest`, `go test ./...`, `cargo test`, `bundle exec rspec`, `mise run test`, `lefthook run pre-commit`. If the project has a single canonical command, prefer it. If anything fails — even a pre-existing failure unrelated to our changes — trigger the **Test failure** stop condition.
+
+### e. Reply, resolve, commit, push
+
+- Reply to and resolve every thread using `/copilot-review` step 9 mutations (multi-line GraphQL, body via temp file).
+- `git add` only the files we actually changed for this iteration. Never `git add -A`.
+- Commit with a message of the form: `chore(copilot): iter N — address <short summary>`.
+- Push: `git push origin <branch>`. **Never** `--force`, `--force-with-lease`, or any rebase flag.
+
+### f. Re-request Copilot review
+
+Trigger a new Copilot review by re-adding it to the requested reviewers list:
+
+```bash
+gh api -X POST "repos/OWNER/REPO/pulls/NUMBER/requested_reviewers" \
+  -f 'reviewers[]=copilot-pull-request-reviewer'
+```
+
+If the request returns 422 because Copilot is already a requested reviewer, first remove it then re-add:
+
+```bash
+gh api -X DELETE "repos/OWNER/REPO/pulls/NUMBER/requested_reviewers" \
+  -f 'reviewers[]=copilot-pull-request-reviewer'
+```
+
+### g. Wait for Copilot's response
+
+Poll the PR's reviews list every 30s, capped at **10 minutes** total per iteration:
+
+```bash
+gh api graphql -f query='
+  query($owner: String!, $repo: String!, $number: Int!) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $number) {
+        reviews(last: 5) {
+          nodes { author { login } state submittedAt }
+        }
+      }
+    }
+  }
+' -f owner='OWNER' -f repo='REPO' -F number=NUMBER
+```
+
+A new Copilot review is one where `author.login == bot login` and `submittedAt > our iteration's push timestamp`.
+
+After the new review appears, re-fetch reviewThreads and compare against the baseline:
+- **Zero new unresolved Copilot threads**: success — exit the loop.
+- **One or more new threads**: increment iteration counter and loop back to (a).
+
+If the 10-minute poll window expires with no new Copilot review, trigger the **No response** stop condition.
+
+### h. Iteration summary
+
+After each iteration, print a short summary:
+- Iteration number / cap
+- Threads addressed (counts by classification: valid / false positive / adjacent finding)
+- Commit SHA pushed
+- Test command run + result
+- Re-review request status
+
+This is what I scroll back through to audit the run.
+
+## Stop conditions (mandatory human handoff)
+
+If any condition fires, **stop**. Print the latest iteration table, name the condition, and wait for me. Do not push, do not reply, do not re-request review.
+
+| Condition | Trigger |
+|---|---|
+| **Ambiguity** | Comment is unclear, has multiple valid interpretations, or requires a product/UX call. |
+| **Loop detection** | Copilot raised a substantively similar concern (same file, same root issue) in two consecutive iterations. |
+| **Scope creep** | A fix would touch code outside the PR's existing diff, or contradicts the PR's stated intent / Jira AC. |
+| **Test failure** | Any test, linter, type-check, or formatter fails after our change — including pre-existing failures we surface for the first time. |
+| **Security-sensitive** | The change touches auth, secrets handling, crypto, permissions, IAM, SQL/shell construction, or sandbox boundaries. Always pause. |
+| **High false-positive ratio** | More than half of an iteration's threads are false positives — model may be misreading the change. Pause for re-alignment. |
+| **Iteration cap** | 10 iterations completed without convergence. Stop and report. |
+| **Cannot reproduce** | Issue is not reproducible and the proposed fix is non-trivial. |
+| **Migrations / data / destructive ops** | Schema migrations, data backfills, deletes, drops, or anything irreversible. Always human-driven. |
+| **No response** | 10-minute poll window expires with no new Copilot review. |
+| **Conflicting signals** | Copilot's later review contradicts an earlier one we already addressed. Pause to decide which to honor. |
+
+## Auto-execution invariants
+
+These hold at every step:
+- **Never** `git push --force` or `--force-with-lease`.
+- **Never** amend, squash, or rebase commits already pushed.
+- **Never** dismiss a thread without an explanatory reply.
+- **Never** skip the failing-test-first step on a behavior-changing fix.
+- **Never** commit or touch files outside the PR's diff to "fix" something we noticed in passing — surface it as an adjacent finding for human review instead.
+- **Never** modify CI configuration, `.env`, secrets, or lockfiles unless the Copilot thread is specifically about that file.
+- **Never** post anything to chat platforms or tickets.
+
+## Maintenance
+
+After completing the workflow (or stopping), check if any part of these instructions seem outdated or misaligned with current tooling: GraphQL schema changes, deprecated fields, new `gh` CLI capabilities, changes to how Copilot reviews are requested or to the bot's login. If something looks off, flag it and offer a ready-to-use prompt I can paste into a new dotfiles session to update this command.
+
+$ARGUMENTS

--- a/roles/osx/files/claude/commands/copilot-pairing.md
+++ b/roles/osx/files/claude/commands/copilot-pairing.md
@@ -10,7 +10,7 @@ You want a hands-off pairing pass with Copilot. The skill loops: address Copilot
 
 1. **Get PR / repo info** (same as `/copilot-review` step 1).
 2. **(Optional) Jira context** (same as `/copilot-review` step 2).
-3. **Confirm the Copilot bot login.** Default is `copilot-pull-request-reviewer`. Verify by inspecting an existing review on the PR:
+3. **Confirm the Copilot bot login and detect repo mode.** Default login is `copilot-pull-request-reviewer`. Verify by inspecting an existing review on the PR:
    ```bash
    gh api graphql -f query='
      query($owner: String!, $repo: String!, $number: Int!) {
@@ -22,7 +22,9 @@ You want a hands-off pairing pass with Copilot. The skill loops: address Copilot
      }
    ' -f owner='OWNER' -f repo='REPO' -F number=NUMBER
    ```
-   Use the actual `Bot` login if it differs.
+   Use the actual `Bot` login if it differs. Then set `repo_mode` from the same `__typename` field:
+   - `__typename == "Bot"` → `repo_mode = "app"`. Copilot is installed as a GitHub App and auto-reviews on push. The REST endpoint `POST /repos/{owner}/{repo}/pulls/{n}/requested_reviewers` will always return 422 ("not a collaborator") because Apps are not collaborators; the auto-review-on-push behavior is the actual mechanism.
+   - Otherwise → `repo_mode = "collaborator"`. Use the explicit re-request POST in step (f).
 4. **Initialize iteration counter** = 0. The loop's per-iteration filter is `isResolved: false` (step (a)), so we don't need to snapshot HEAD or the baseline thread-ID set.
 
 ## Iteration loop
@@ -90,16 +92,26 @@ Order matters: land the code first, then talk about it. If we replied/resolved b
 3. Resolve threads via `resolveReviewThread`.
 4. Proceed to step (f.5), not (f): do not re-request review against an unchanged HEAD, since Copilot will not respond and step (g) will time out.
 
-### f. Re-request Copilot review (best-effort)
+### f. Re-request Copilot review (best-effort, mode-aware)
 
-Try to trigger a new Copilot review by re-adding it to the requested reviewers list:
+Branch on `repo_mode` from pre-flight step 3.
+
+**`app` mode (`__typename == "Bot"` in pre-flight):** skip the POST entirely. Auto-review on push handles the trigger. Log a single line for the iteration summary:
+
+```
+App-mode repo, auto-review on push will trigger Copilot. Skipping explicit re-request.
+```
+
+Then proceed to step (g). **Step (g) is mandatory in App mode.** Auto-review-on-push triggers Copilot, but only step (g)'s poll confirms it actually reviewed. Skipping (g) on the assumption that "push = review" is the regression this branch's wording was written to prevent.
+
+**`collaborator` mode:** try to trigger a new Copilot review by re-adding it to the requested reviewers list.
 
 ```bash
 gh api -X POST "repos/OWNER/REPO/pulls/NUMBER/requested_reviewers" \
   -f 'reviewers[]=copilot-pull-request-reviewer'
 ```
 
-This call is **best-effort**, not load-bearing. The actual signal the loop relies on is step (g)'s GraphQL poll for a new review. Repos where Copilot is installed as a GitHub App typically auto-review on push, so an explicit re-request is unnecessary (and the REST endpoint will reject it).
+This call is **best-effort**, not load-bearing. The actual signal the loop relies on is step (g)'s GraphQL poll for a new review.
 
 Inspect the response and branch:
 
@@ -107,7 +119,7 @@ Inspect the response and branch:
 |---|---|---|
 | 2xx | — | Proceed to step (g). |
 | 422 | `already requested` (or similar "duplicate reviewer") | DELETE the reviewer, re-POST. Then proceed to step (g). |
-| 422 | `not a collaborator` (or any other 422) | Log a single-line warning that the explicit re-request was rejected (likely auto-review-on-push repo). Proceed to step (g). |
+| 422 | `not a collaborator` | Pre-flight mode detection was wrong (the bot is no longer a Bot-typed reviewer). Log the mismatch and proceed to step (g). On the next run, re-check pre-flight step 3. |
 | Other (4xx/5xx) | — | Log warning. Proceed to step (g). |
 
 DELETE+POST retry pattern (only for the `already requested` case):
@@ -132,6 +144,8 @@ Only reached if step (e) produced no commits. Re-fetch reviewThreads (same query
 Skip steps (f) and (g) on this path.
 
 ### g. Wait for Copilot's response
+
+**This step is mandatory after every Path-A push, in both `app` and `collaborator` modes.** Do not infer that Copilot has reviewed from any other signal: not the push itself, not step (f)'s HTTP outcome, not "the last N iterations all converged so this one will too". The poll below is the only authoritative confirmation.
 
 We need to wait up to **10 minutes** for a new Copilot review. Do not foreground-sleep or chain `sleep` calls between polls: the harness's Bash tool blocks long sleeps and chained sleeps. Use one of the two patterns below.
 
@@ -193,7 +207,7 @@ After each iteration, print a short summary:
 - Threads addressed (counts by classification: valid / false positive / adjacent finding)
 - Commit SHA pushed
 - Test command run + result
-- Re-review request status
+- Re-review request status: in `app` mode, report `n/a (App-mode auto-review)`; in `collaborator` mode, report the actual HTTP outcome from step (f).
 
 This is what I scroll back through to audit the run.
 
@@ -225,6 +239,7 @@ These hold at every step:
 - **Never** commit or touch files outside the PR's diff to "fix" something we noticed in passing. Surface it as an adjacent finding for human review instead.
 - **Never** modify CI configuration, `.env`, secrets, or lockfiles unless the Copilot thread is specifically about that file.
 - **Never** post anything to chat platforms or tickets.
+- **Never** skip step (g) after a Path-A push. The 10-minute poll is the only authoritative signal that Copilot has (or has not) reviewed. App-mode auto-review, step (f)'s HTTP outcome, prior iterations' patterns, and elapsed iteration count are not substitutes. Confirmation bias from a long successful run is the failure mode this invariant catches.
 
 ## Maintenance
 

--- a/roles/osx/files/claude/commands/copilot-pairing.md
+++ b/roles/osx/files/claude/commands/copilot-pairing.md
@@ -76,11 +76,11 @@ Order matters: land the code first, then talk about it. If we replied/resolved b
    - `git add` only the files we actually changed for this iteration (never `git add -A`).
    - Commit with a message of the form `chore(copilot): iter N, address <short summary>`.
    - Push: `git push origin <branch>`. **Never** `--force`, `--force-with-lease`, or any rebase flag.
-2. **Capture push timestamp.** Immediately after push completes:
+2. **Capture push timestamp.** Immediately after push completes (substitute the PR number from pre-flight step 1):
    ```bash
-   date -u +%Y-%m-%dT%H:%M:%SZ > /tmp/copilot-pairing-push-ts
+   date -u +%Y-%m-%dT%H:%M:%SZ > /tmp/copilot-pairing-push-ts.NUMBER
    ```
-   The Bash tool spawns a fresh shell per invocation, so a plain shell variable will not be visible to the step (g) script. Use the temp file, or inline the literal value into the step (g) script when you send it. This timestamp is the high-water mark for step (g)'s poll filter; capturing it any earlier risks matching a Copilot review that pre-dates this push.
+   The Bash tool spawns a fresh shell per invocation, so a plain shell variable will not be visible to the step (g) script. Use the temp file, or inline the literal value into the step (g) script when you send it. The filename is namespaced by PR number so concurrent pairing sessions on different PRs (e.g., separate worktrees) do not clobber each other's timestamp. This timestamp is the high-water mark for step (g)'s poll filter; capturing it any earlier risks matching a Copilot review that pre-dates this push.
 3. **Reply to threads** using `/copilot-review` step 8 mutations (multi-line GraphQL, body via temp file). **Use `addPullRequestReviewThreadReply` only**; see the DO-NOT-USE callout in `/copilot-review` step 8 about `addPullRequestReviewComment`.
 4. **Resolve threads** using `/copilot-review` step 8's `resolveReviewThread` mutation.
 5. Proceed to step (f).
@@ -88,7 +88,7 @@ Order matters: land the code first, then talk about it. If we replied/resolved b
 **Path B (no code changes, every thread was `already-handled`):**
 
 1. Skip commit/push and skip the push-timestamp capture (no new HEAD; step (g) is skipped on this path).
-2. Reply to each thread with a short body referencing the prior commit that actually addressed it. Find the commit via `git log main..HEAD --oneline -- <file>` (scoped to this branch's commits, top entry is the most recent). Use `addPullRequestReviewThreadReply` (same DO-NOT-USE callout applies).
+2. Reply to each thread with a short body referencing the prior commit that actually addressed it. Find the commit via `git log "$(gh pr view --json baseRefName -q '.baseRefName')..HEAD" --oneline -- <file>` (scoped to this branch's commits, top entry is the most recent). Do not hardcode `main`: PRs targeting `develop`, `release/*`, or any other base branch would otherwise return wrong or empty commits. Use `addPullRequestReviewThreadReply` (same DO-NOT-USE callout applies).
 3. Resolve threads via `resolveReviewThread`.
 4. Proceed to step (f.5), not (f): do not re-request review against an unchanged HEAD, since Copilot will not respond and step (g) will time out.
 
@@ -154,8 +154,9 @@ We need to wait up to **10 minutes** for a new Copilot review. Do not foreground
 ```bash
 # Read push_ts from the temp file written in step (e). Bash tool calls do not
 # share shell state, so reading from the file (or inlining the literal value
-# before sending the script) is required.
-push_ts=$(cat /tmp/copilot-pairing-push-ts 2>/dev/null)
+# before sending the script) is required. The file is namespaced by PR number;
+# substitute NUMBER from pre-flight step 1.
+push_ts=$(cat /tmp/copilot-pairing-push-ts.NUMBER 2>/dev/null)
 [ -n "$push_ts" ] || { echo "push_ts not set; capture it in step (e) before running"; exit 2; }
 deadline=$(( $(date +%s) + 600 ))
 while [ $(date +%s) -lt $deadline ]; do
@@ -185,9 +186,9 @@ Branch on the script's exit:
 - **Exit 0 (`NEW_REVIEW`)**: re-fetch reviewThreads. If any are unresolved, increment iteration counter and loop back to (a). If zero unresolved, success: exit the loop.
 - **Exit 1 (`TIMEOUT`)**: trigger the **No response** stop condition.
 - **Exit 2 (bad input)**: step (e) failed to capture `push_ts`. Bug in our flow. Stop and surface the script's stderr.
-- **Any other exit code (e.g. 144 from external SIGTERM, OOM kill, harness session end)**: the script was killed externally; its output is not authoritative. Re-query GraphQL directly using the `push_ts` from `/tmp/copilot-pairing-push-ts`:
+- **Any other exit code (e.g. 144 from external SIGTERM, OOM kill, harness session end)**: the script was killed externally; its output is not authoritative. Re-query GraphQL directly using the `push_ts` from `/tmp/copilot-pairing-push-ts.NUMBER`:
   ```bash
-  push_ts=$(cat /tmp/copilot-pairing-push-ts)
+  push_ts=$(cat /tmp/copilot-pairing-push-ts.NUMBER)
   gh api graphql -f query='...same as the poll script...' \
     -f owner='OWNER' -f repo='REPO' -F number=NUMBER \
     | jq --arg bot 'copilot-pull-request-reviewer' --arg ts "$push_ts" '

--- a/roles/osx/files/claude/commands/copilot-pairing.md
+++ b/roles/osx/files/claude/commands/copilot-pairing.md
@@ -48,6 +48,7 @@ Be more conservative than in `/copilot-review` because nobody is checking our wo
 - If the three passes do not converge, mark `low-confidence` and trigger the **Cannot reproduce** or **Ambiguity** stop condition (whichever fits).
 - If two valid interpretations exist, trigger **Ambiguity**.
 - If the fix would touch a file outside the PR's existing diff, trigger **Scope creep**.
+- After classifying every thread, if more than half of this iteration's threads are `false positive`, trigger **High false-positive ratio** (the model may be misreading the change; pause for re-alignment rather than spamming dismissals).
 - Apply the same three-pass rigor to every proposed fix. Do not trust Copilot's recommendation; design our own from first principles, then validate it from three angles before accepting.
 
 ### c. Implement valid items: solution validated with two or three test angles
@@ -78,21 +79,22 @@ Order matters: land the code first, then talk about it. If we replied/resolved b
    - `git add` only the files we actually changed for this iteration (never `git add -A`).
    - Commit with a message of the form `chore(copilot): iter N, address <short summary>`.
    - Push: `git push origin <branch>`. **Never** `--force`, `--force-with-lease`, or any rebase flag.
-2. **Capture push timestamp** in two forms, ISO-8601 for the GraphQL string compare and Unix epoch for deadline math (substitute the PR number from pre-flight step 1):
+2. **Capture push timestamp** as a Unix epoch, used for both deadline math and the poll filter (substitute the PR number from pre-flight step 1):
    ```bash
-   date -u +%Y-%m-%dT%H:%M:%SZ > /tmp/copilot-pairing-push-ts.NUMBER
-   date +%s                    > /tmp/copilot-pairing-push-epoch.NUMBER
+   date +%s > /tmp/copilot-pairing-push-epoch.NUMBER
    ```
-   The Bash tool spawns a fresh shell per invocation, so a plain shell variable will not be visible to the step (g) script. Use the temp files, or inline the literal values into the step (g) script when you send it. The filenames are namespaced by PR number so concurrent pairing sessions on different PRs (e.g., separate worktrees) do not clobber each other's timestamps. Capture both timestamps in the same `Bash` call so they cannot drift from each other. This high-water mark is the floor for step (g)'s poll filter; capturing it any earlier risks matching a Copilot review that pre-dates this push.
+   The Bash tool spawns a fresh shell per invocation, so a plain shell variable will not be visible to the step (g) script. Use the temp file, or inline the literal value into the step (g) script when you send it. The filename is namespaced by PR number so concurrent pairing sessions on different PRs (e.g., separate worktrees) do not clobber each other's timestamps. We use epoch (not ISO-8601) so the poll filter can compare numerically via `fromdateiso8601` and avoid lexicographic edge cases at sub-second precision. This high-water mark is the floor for step (g)'s poll filter; capturing it any earlier risks matching a Copilot review that pre-dates this push.
 3. **Reply to threads** using `/copilot-review` step 8 mutations (multi-line GraphQL, body via temp file). **Use `addPullRequestReviewThreadReply` only**; see the DO-NOT-USE callout in `/copilot-review` step 8 about `addPullRequestReviewComment`.
 4. **Submit any auto-vivified pending review (mandatory).** `addPullRequestReviewThreadReply` can create a new pending review owned by the viewer when none is in progress; the replies posted in (e.3) then stay invisible (to GitHub UI, to Copilot, to humans) until that review is submitted. See `/copilot-review` step 8's "Submit any auto-vivified pending review" sub-step for the exact GraphQL. Procedure: query the PR's `reviews(states: PENDING)` filtered by `author.login == viewer.login`; for each, call `submitPullRequestReview(id, event: COMMENT)`. Re-query and assert zero pending reviews owned by the viewer remain before proceeding to step (e.5). If a pending review cannot be submitted, stop with the **Pending reply unsubmittable** condition.
 5. **Resolve threads** using `/copilot-review` step 8's `resolveReviewThread` mutation.
 6. Proceed to step (f).
 
-**Path B (no code changes, every thread was `already-handled`):**
+**Path B (no code changes; every thread was `already-handled` or `false positive`):**
 
 1. Skip commit/push and skip the push-timestamp capture (no new HEAD; step (g) is skipped on this path).
-2. Reply to each thread with a short body referencing the prior commit that actually addressed it. Find the commit via `git log "$(gh pr view --json baseRefName -q '.baseRefName')..HEAD" --oneline -- <file>` (scoped to this branch's commits, top entry is the most recent). Do not hardcode `main`: PRs targeting `develop`, `release/*`, or any other base branch would otherwise return wrong or empty commits. Use `addPullRequestReviewThreadReply` (same DO-NOT-USE callout applies).
+2. Post the reply for each thread, varying by classification (use `addPullRequestReviewThreadReply` either way; same DO-NOT-USE callout applies):
+   - **`already-handled`**: reply with a short body referencing the prior commit that actually addressed it. Find the commit via `git log "$(gh pr view --json baseRefName -q '.baseRefName')..HEAD" --oneline -- <file>` (scoped to this branch's commits, top entry is the most recent). Do not hardcode `main`: PRs targeting `develop`, `release/*`, or any other base branch would otherwise return wrong or empty commits.
+   - **`false positive`**: post the dismissal reply drafted in step (b) (citing the three passes and why the concern does not apply).
 3. **Submit any auto-vivified pending review (mandatory).** Same procedure as Path A step 4. The auto-vivify failure mode applies here too because we still call `addPullRequestReviewThreadReply`.
 4. Resolve threads via `resolveReviewThread`.
 5. Proceed to step (f.5), not (f): do not re-request review against an unchanged HEAD, since Copilot will not respond and step (g) will time out.
@@ -183,13 +185,12 @@ We need to wait up to **10 minutes** for a new Copilot review. Do not foreground
 **Preferred: a single backgrounded poll script** (`Bash` with `run_in_background=true`). The script polls itself and exits when the condition is met or the deadline passes. You'll be notified when it exits. Substitute the verified bot login from pre-flight step 3 in the `--arg bot ...` flag if it differs from the default.
 
 ```bash
-# Read push_ts and push_epoch from the temp files written in step (e). Bash
-# tool calls do not share shell state, so reading from the files (or inlining
-# the literal values before sending the script) is required. Files are
-# namespaced by PR number; substitute NUMBER from pre-flight step 1.
-push_ts=$(cat /tmp/copilot-pairing-push-ts.NUMBER 2>/dev/null)
+# Read push_epoch from the temp file written in step (e). Bash tool calls do
+# not share shell state, so reading from the file (or inlining the literal
+# value before sending the script) is required. File is namespaced by PR
+# number; substitute NUMBER from pre-flight step 1.
 push_epoch=$(cat /tmp/copilot-pairing-push-epoch.NUMBER 2>/dev/null)
-[ -n "$push_ts" ] && [ -n "$push_epoch" ] || { echo "push_ts/push_epoch not set; capture them in step (e) before running"; exit 2; }
+[ -n "$push_epoch" ] || { echo "push_epoch not set; capture it in step (e) before running"; exit 2; }
 deadline=$(( push_epoch + 600 ))
 while [ $(date +%s) -lt $deadline ]; do
   latest=$(gh api graphql -f query='
@@ -201,9 +202,9 @@ while [ $(date +%s) -lt $deadline ]; do
       }
     }
   ' -f owner='OWNER' -f repo='REPO' -F number=NUMBER \
-    | jq -r --arg bot 'copilot-pull-request-reviewer' --arg ts "$push_ts" '
+    | jq -r --arg bot 'copilot-pull-request-reviewer' --argjson since "$push_epoch" '
         .data.repository.pullRequest.reviews.nodes
-        | map(select(.author.login == $bot and .submittedAt > $ts))
+        | map(select(.author.login == $bot and (.submittedAt | sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601) > $since))
         | last // empty')
   if [ -n "$latest" ]; then echo "NEW_REVIEW $latest"; exit 0; fi
   sleep 30
@@ -217,16 +218,15 @@ Branch on the script's exit:
 
 - **Exit 0 (`NEW_REVIEW`)**: re-fetch reviewThreads. If any are unresolved, increment iteration counter and loop back to (a). If zero unresolved, success: exit the loop.
 - **Exit 1 (`TIMEOUT`)**: trigger the **No response** stop condition.
-- **Exit 2 (bad input)**: step (e) failed to capture `push_ts` or `push_epoch`. Bug in our flow. Stop and surface the script's stderr.
-- **Any other exit code (e.g. 143 from SIGTERM, 137 from SIGKILL/OOM, or any 128+N signal exit from a harness session end)**: the script was killed externally; its output is not authoritative. Re-query GraphQL directly using the `push_ts` from `/tmp/copilot-pairing-push-ts.NUMBER`, and read `push_epoch` from `/tmp/copilot-pairing-push-epoch.NUMBER` for the deadline check:
+- **Exit 2 (bad input)**: step (e) failed to capture `push_epoch`. Bug in our flow. Stop and surface the script's stderr.
+- **Any other exit code (e.g. 143 from SIGTERM, 137 from SIGKILL/OOM, or any 128+N signal exit from a harness session end)**: the script was killed externally; its output is not authoritative. Re-query GraphQL directly, reading `push_epoch` from `/tmp/copilot-pairing-push-epoch.NUMBER` for both the deadline check and the poll filter:
   ```bash
-  push_ts=$(cat /tmp/copilot-pairing-push-ts.NUMBER)
   push_epoch=$(cat /tmp/copilot-pairing-push-epoch.NUMBER)
   gh api graphql -f query='...same as the poll script...' \
     -f owner='OWNER' -f repo='REPO' -F number=NUMBER \
-    | jq --arg bot 'copilot-pull-request-reviewer' --arg ts "$push_ts" '
+    | jq --arg bot 'copilot-pull-request-reviewer' --argjson since "$push_epoch" '
         .data.repository.pullRequest.reviews.nodes
-        | map(select(.author.login == $bot and .submittedAt > $ts))'
+        | map(select(.author.login == $bot and (.submittedAt | sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601) > $since))'
   ```
   - **New Copilot review found**: treat as `NEW_REVIEW` and proceed as above.
   - **No new review, still inside the 10-minute window** (`[ $(date +%s) -lt $((push_epoch + 600)) ]`): restart the background poll script. Cap restarts at **2** per iteration to prevent thrashing; after that, treat as **No response**.

--- a/roles/osx/files/claude/commands/copilot-pairing.md
+++ b/roles/osx/files/claude/commands/copilot-pairing.md
@@ -34,7 +34,9 @@ For each iteration (cap = **10**):
 
 ### a. Fetch Copilot's open threads
 
-Use the same GraphQL query as `/copilot-review` step 3. Filter to threads where `isResolved: false` AND first comment author login == Copilot bot login. Do not add a "skip if older than last push" filter: `isResolved: false` is the canonical signal. If a previous iteration's resolve mutation failed silently, we want this loop to retry it, not skip it. Re-processing an already-fixed thread is safe (passes will classify it as no-op / already-handled and the resolve mutation re-fires).
+Use the same GraphQL query as `/copilot-review` step 3. Filter to threads where `isResolved: false` AND first comment author login == Copilot bot login. Do not add a "skip if older than last push" filter: `isResolved: false` is the canonical signal, and a previous iteration's resolve mutation may have failed silently; this loop should retry it, not skip it.
+
+**Pre-check for already-handled threads.** Before running the validation passes, read the referenced file and decide whether the code already implements what Copilot asked for (because a prior iteration applied the fix but the resolve mutation never landed). If yes, classify the thread as `already-handled`, skip steps (b) and (c) for it, and let step (e) post a brief reply ("addressed in <commit-sha>") and re-fire the resolve mutation. This is what keeps a benign retry from tripping the **Cannot reproduce** stop condition in step (b)'s Pass 1.
 
 ### b. Validate every thread (strict, three passes minimum)
 
@@ -90,29 +92,40 @@ gh api -X DELETE "repos/OWNER/REPO/pulls/NUMBER/requested_reviewers" \
 
 ### g. Wait for Copilot's response
 
-Poll the PR's reviews list every 30s, capped at **10 minutes** total per iteration:
+We need to wait up to **10 minutes** for a new Copilot review. Do not foreground-sleep or chain `sleep` calls between polls: the harness's Bash tool blocks long sleeps and chained sleeps. Use one of the two patterns below.
+
+**Preferred: a single backgrounded poll script** (`Bash` with `run_in_background=true`). The script polls itself and exits when the condition is met or the deadline passes. You'll be notified when it exits.
 
 ```bash
-gh api graphql -f query='
-  query($owner: String!, $repo: String!, $number: Int!) {
-    repository(owner: $owner, name: $repo) {
-      pullRequest(number: $number) {
-        reviews(last: 5) {
-          nodes { author { login } state submittedAt }
+push_ts='ITERATION_PUSH_ISO8601'   # the push time from step (e)
+deadline=$(( $(date +%s) + 600 ))
+while [ $(date +%s) -lt $deadline ]; do
+  latest=$(gh api graphql -f query='
+    query($owner: String!, $repo: String!, $number: Int!) {
+      repository(owner: $owner, name: $repo) {
+        pullRequest(number: $number) {
+          reviews(last: 5) { nodes { author { login } state submittedAt } }
         }
       }
     }
-  }
-' -f owner='OWNER' -f repo='REPO' -F number=NUMBER
+  ' -f owner='OWNER' -f repo='REPO' -F number=NUMBER \
+    | jq -r --arg bot 'copilot-pull-request-reviewer' --arg ts "$push_ts" '
+        .data.repository.pullRequest.reviews.nodes
+        | map(select(.author.login == $bot and .submittedAt > $ts))
+        | last // empty')
+  if [ -n "$latest" ]; then echo "NEW_REVIEW $latest"; exit 0; fi
+  sleep 30
+done
+echo "TIMEOUT"; exit 1
 ```
 
-A new Copilot review is one where `author.login == bot login` and `submittedAt > our iteration's push timestamp`.
+**Alternative**: `Monitor` the same script with an until-loop if you want streaming progress lines.
 
-After the new review appears, re-fetch reviewThreads and compare against the baseline:
+After the script reports `NEW_REVIEW`, re-fetch reviewThreads and compare against the baseline:
 - **Zero new unresolved Copilot threads**: success. Exit the loop.
 - **One or more new threads**: increment iteration counter and loop back to (a).
 
-If the 10-minute poll window expires with no new Copilot review, trigger the **No response** stop condition.
+If the script reports `TIMEOUT`, trigger the **No response** stop condition.
 
 ### h. Iteration summary
 

--- a/roles/osx/files/claude/commands/copilot-pairing.md
+++ b/roles/osx/files/claude/commands/copilot-pairing.md
@@ -10,13 +10,13 @@ You want a hands-off pairing pass with Copilot. The skill loops: address Copilot
 
 1. **Get PR / repo info** (same as `/copilot-review` step 1).
 2. **(Optional) Jira context** (same as `/copilot-review` step 2).
-3. **Confirm the Copilot bot login and detect repo mode.** Default login is `copilot-pull-request-reviewer`. Verify by inspecting an existing review on the PR:
+3. **Confirm the Copilot bot login and detect repo mode.** Default login is `copilot-pull-request-reviewer`. Verify by inspecting an existing review on the PR (`reviews(last: 5)` so we surface the most-recent reviews; `first: 5` would return the oldest and may not include Copilot on a long-lived PR):
    ```bash
    gh api graphql -f query='
      query($owner: String!, $repo: String!, $number: Int!) {
        repository(owner: $owner, name: $repo) {
          pullRequest(number: $number) {
-           reviews(first: 5) { nodes { author { __typename login } } }
+           reviews(last: 5) { nodes { author { __typename login } } }
          }
        }
      }

--- a/roles/osx/files/claude/commands/copilot-pairing.md
+++ b/roles/osx/files/claude/commands/copilot-pairing.md
@@ -104,7 +104,7 @@ App-mode repo, auto-review on push will trigger Copilot. Skipping explicit re-re
 
 Then proceed to step (g). **Step (g) is mandatory in App mode.** Auto-review-on-push triggers Copilot, but only step (g)'s poll confirms it actually reviewed. Skipping (g) on the assumption that "push = review" is the regression this branch's wording was written to prevent.
 
-**`collaborator` mode:** try to trigger a new Copilot review by re-adding it to the requested reviewers list.
+**`collaborator` mode:** try to trigger a new Copilot review by re-adding it to the requested reviewers list. Substitute the verified bot login from pre-flight step 3 if it differs from the default.
 
 ```bash
 gh api -X POST "repos/OWNER/REPO/pulls/NUMBER/requested_reviewers" \
@@ -139,7 +139,7 @@ Do NOT trigger the **No response** stop condition based on this step's HTTP outc
 Only reached if step (e) produced no commits. Re-fetch reviewThreads (same query as step (a)) and count unresolved Copilot threads:
 
 - **Zero remaining**: success. Exit the loop. Print the iteration summary noting "resolve-only iteration, no new code, all Copilot threads now resolved".
-- **One or more remaining** (rare: a resolve mutation failed again): increment iteration counter and loop back to step (a). If the same threads remain unresolved across two consecutive iterations, trigger the **Loop detection** stop condition.
+- **One or more remaining** (rare: a resolve mutation failed again): increment iteration counter and loop back to step (a). If the same threads remain unresolved across two consecutive iterations, trigger the **Persistent resolve failure** stop condition.
 
 Skip steps (f) and (g) on this path.
 
@@ -149,7 +149,7 @@ Skip steps (f) and (g) on this path.
 
 We need to wait up to **10 minutes** for a new Copilot review. Do not foreground-sleep or chain `sleep` calls between polls: the harness's Bash tool blocks long sleeps and chained sleeps. Use one of the two patterns below.
 
-**Preferred: a single backgrounded poll script** (`Bash` with `run_in_background=true`). The script polls itself and exits when the condition is met or the deadline passes. You'll be notified when it exits.
+**Preferred: a single backgrounded poll script** (`Bash` with `run_in_background=true`). The script polls itself and exits when the condition is met or the deadline passes. You'll be notified when it exits. Substitute the verified bot login from pre-flight step 3 in the `--arg bot ...` flag if it differs from the default.
 
 ```bash
 # Read push_ts from the temp file written in step (e). Bash tool calls do not
@@ -186,7 +186,7 @@ Branch on the script's exit:
 - **Exit 0 (`NEW_REVIEW`)**: re-fetch reviewThreads. If any are unresolved, increment iteration counter and loop back to (a). If zero unresolved, success: exit the loop.
 - **Exit 1 (`TIMEOUT`)**: trigger the **No response** stop condition.
 - **Exit 2 (bad input)**: step (e) failed to capture `push_ts`. Bug in our flow. Stop and surface the script's stderr.
-- **Any other exit code (e.g. 144 from external SIGTERM, OOM kill, harness session end)**: the script was killed externally; its output is not authoritative. Re-query GraphQL directly using the `push_ts` from `/tmp/copilot-pairing-push-ts.NUMBER`:
+- **Any other exit code (e.g. 143 from SIGTERM, 137 from SIGKILL/OOM, or any 128+N signal exit from a harness session end)**: the script was killed externally; its output is not authoritative. Re-query GraphQL directly using the `push_ts` from `/tmp/copilot-pairing-push-ts.NUMBER`:
   ```bash
   push_ts=$(cat /tmp/copilot-pairing-push-ts.NUMBER)
   gh api graphql -f query='...same as the poll script...' \
@@ -220,6 +220,7 @@ If any condition fires, **stop**. Print the latest iteration table, name the con
 |---|---|
 | **Ambiguity** | Comment is unclear, has multiple valid interpretations, or requires a product/UX call. |
 | **Loop detection** | Copilot raised a substantively similar concern (same file, same root issue) in two consecutive iterations. |
+| **Persistent resolve failure** | A `resolveReviewThread` mutation has silently failed (or been rolled back) for the same threads across two consecutive iterations, so the resolve-only short-circuit in step f.5 cannot drain the queue. |
 | **Scope creep** | A fix would touch code outside the PR's existing diff, or contradicts the PR's stated intent / Jira AC. |
 | **Test failure** | Any test, linter, type-check, or formatter fails after our change, including pre-existing failures we surface for the first time. |
 | **Security-sensitive** | The change touches auth, secrets handling, crypto, permissions, IAM, SQL/shell construction, or sandbox boundaries. Always pause. |

--- a/roles/osx/files/claude/commands/copilot-pairing.md
+++ b/roles/osx/files/claude/commands/copilot-pairing.md
@@ -243,10 +243,11 @@ Never assume "loop succeeded" from a non-zero, non-1 exit code. Always cross-che
 
 After each iteration, print a short summary:
 - Iteration number / cap
-- Threads addressed (counts by classification: valid / false positive / adjacent finding)
-- Commit SHA pushed
-- Test command run + result
-- Re-review request status: in `app` mode, report the outcome of step (f)'s `request_copilot_review` MCP call plus the `reviewRequests.nodes` verification result; in `collaborator` mode, report the actual HTTP outcome from step (f).
+- Path taken (A = code changes pushed, B = resolve-only)
+- Threads addressed (counts by classification: valid / already-handled / false positive / adjacent finding)
+- Commit SHA pushed (Path A only; `n/a` on Path B)
+- Test command run + result (Path A only; `n/a` on Path B since no code changed)
+- Re-review request status: Path A only. In `app` mode, report the outcome of step (f)'s `request_copilot_review` MCP call plus the `reviewRequests.nodes` verification result; in `collaborator` mode, report the actual HTTP outcome from step (f). On Path B, `n/a` (step (f) is skipped).
 
 This is what I scroll back through to audit the run.
 

--- a/roles/osx/files/claude/commands/copilot-pairing.md
+++ b/roles/osx/files/claude/commands/copilot-pairing.md
@@ -204,7 +204,7 @@ Skip steps (f) and (g) on this path.
 
 **This step is mandatory after every Path-A push, in both `app` and `collaborator` modes.** Do not infer that Copilot has reviewed from any other signal: not the push itself, not step (f)'s HTTP outcome, not "the last N iterations all converged so this one will too". The poll below is the only authoritative confirmation.
 
-We need to wait up to **10 minutes** for a new Copilot review. Do not foreground-sleep or chain `sleep` calls between polls: the harness's Bash tool blocks long sleeps and chained sleeps. Use one of the two patterns below.
+We need to wait up to **10 minutes** for a new Copilot review. The harness's Bash tool blocks long leading sleeps and shorter sleeps chained across multiple tool calls (the limit applies at the tool-invocation boundary, not inside a running process). So do not poll by issuing one Bash tool call per attempt with `sleep` between them. Both patterns below are safe because the sleeping happens *inside* a single backgrounded invocation that the harness does not introspect.
 
 **Preferred: a single backgrounded poll script** (`Bash` with `run_in_background=true`). The script polls itself and exits when the condition is met or the deadline passes. You'll be notified when it exits. Substitute the verified bot login from pre-flight step 3 in the `--arg bot ...` flag if it differs from the default.
 

--- a/roles/osx/files/claude/commands/copilot-pairing.md
+++ b/roles/osx/files/claude/commands/copilot-pairing.md
@@ -23,7 +23,7 @@ You want a hands-off pairing pass with Copilot. The skill loops: address Copilot
    ' -f owner='OWNER' -f repo='REPO' -F number=NUMBER
    ```
    Use the actual `Bot` login if it differs. Then set `repo_mode` from the same `__typename` field:
-   - `__typename == "Bot"` → `repo_mode = "app"`. Copilot is installed as a GitHub App and auto-reviews on push. The REST endpoint `POST /repos/{owner}/{repo}/pulls/{n}/requested_reviewers` will always return 422 ("not a collaborator") because Apps are not collaborators; the auto-review-on-push behavior is the actual mechanism.
+   - `__typename == "Bot"` → `repo_mode = "app"`. Copilot is installed as a GitHub App, not a collaborator. The REST endpoint `POST /repos/{owner}/{repo}/pulls/{n}/requested_reviewers` returns 422 ("not a collaborator") for App-typed reviewers and must NOT be used in this mode. Step (f) instead calls the `request_copilot_review` MCP tool (which wraps an internal endpoint that accepts Bot reviewers). Do not assume push alone will trigger a Copilot review: auto-review-on-push has been observed to silently no-op (see step (f) for the verified failure mode), so step (g)'s 10-minute poll is the only authoritative confirmation that Copilot has reviewed.
    - Otherwise → `repo_mode = "collaborator"`. Use the explicit re-request POST in step (f).
 4. **Initialize iteration counter** = 0. The loop's per-iteration filter is `isResolved: false` (step (a)), so we don't need to snapshot HEAD or the baseline thread-ID set.
 
@@ -236,7 +236,7 @@ After each iteration, print a short summary:
 - Threads addressed (counts by classification: valid / false positive / adjacent finding)
 - Commit SHA pushed
 - Test command run + result
-- Re-review request status: in `app` mode, report `n/a (App-mode auto-review)`; in `collaborator` mode, report the actual HTTP outcome from step (f).
+- Re-review request status: in `app` mode, report the outcome of step (f)'s `request_copilot_review` MCP call plus the `reviewRequests.nodes` verification result; in `collaborator` mode, report the actual HTTP outcome from step (f).
 
 This is what I scroll back through to audit the run.
 
@@ -266,7 +266,7 @@ If any condition fires, **stop**. Print the latest iteration table, name the con
 These hold at every step:
 - **Never** `git push --force` or `--force-with-lease`.
 - **Never** amend, squash, or rebase commits already pushed.
-- **Never** dismiss a thread without an explanatory reply.
+- **Never** resolve a thread without an explanatory reply.
 - **Never** skip the failing-test-first step on a behavior-changing fix.
 - **Never** commit or touch files outside the PR's diff to "fix" something we noticed in passing. Surface it as an adjacent finding for human review instead.
 - **Never** modify CI configuration, `.env`, secrets, or lockfiles unless the Copilot thread is specifically about that file.

--- a/roles/osx/files/claude/commands/copilot-pairing.md
+++ b/roles/osx/files/claude/commands/copilot-pairing.md
@@ -70,7 +70,7 @@ Run whatever the project ships for local verification: tests, linters, type chec
 - Reply to and resolve every thread using `/copilot-review` step 8 mutations (multi-line GraphQL, body via temp file).
 - If this iteration produced **no code changes** (every thread was classified `already-handled` and we only re-fired the resolves), skip the commit / push and go to step (f.5) below: do not re-request review against an unchanged HEAD, since Copilot will not respond and step (g) will time out.
 - Otherwise: `git add` only the files we actually changed for this iteration (never `git add -A`). Commit with a message of the form `chore(copilot): iter N, address <short summary>`. Push: `git push origin <branch>`. **Never** `--force`, `--force-with-lease`, or any rebase flag.
-- Immediately after the push completes, capture `push_ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)`. This is the high-water mark used by step (g)'s poll filter; capturing it any earlier risks matching a Copilot review that pre-dates this iteration's push.
+- Immediately after the push completes, capture the timestamp and persist it for step (g): `date -u +%Y-%m-%dT%H:%M:%SZ > /tmp/copilot-pairing-push-ts`. The Bash tool spawns a fresh shell per invocation, so a plain shell variable will not be visible to the step (g) script. Use the temp file, or inline the literal value into the step (g) script when you send it. This timestamp is the high-water mark used by step (g)'s poll filter; capturing it any earlier risks matching a Copilot review that pre-dates this iteration's push.
 
 ### f. Re-request Copilot review
 
@@ -100,7 +100,7 @@ Only reached if step (e) produced no commits. Re-fetch reviewThreads (same query
 - **Zero remaining**: success. Exit the loop. Print the iteration summary noting "resolve-only iteration, no new code, all Copilot threads now resolved".
 - **One or more remaining** (rare: a resolve mutation failed again): increment iteration counter and loop back to step (a). If the same threads remain unresolved across two consecutive iterations, trigger the **Loop detection** stop condition.
 
-Skip step (g) entirely on this path.
+Skip steps (f) and (g) on this path.
 
 ### g. Wait for Copilot's response
 
@@ -109,8 +109,10 @@ We need to wait up to **10 minutes** for a new Copilot review. Do not foreground
 **Preferred: a single backgrounded poll script** (`Bash` with `run_in_background=true`). The script polls itself and exits when the condition is met or the deadline passes. You'll be notified when it exits.
 
 ```bash
-# `push_ts` must already be set in this shell from step (e)'s capture.
-# Sanity check; abort rather than silently using an empty filter:
+# Read push_ts from the temp file written in step (e). Bash tool calls do not
+# share shell state, so reading from the file (or inlining the literal value
+# before sending the script) is required.
+push_ts=$(cat /tmp/copilot-pairing-push-ts 2>/dev/null)
 [ -n "$push_ts" ] || { echo "push_ts not set; capture it in step (e) before running"; exit 2; }
 deadline=$(( $(date +%s) + 600 ))
 while [ $(date +%s) -lt $deadline ]; do

--- a/roles/osx/files/claude/commands/copilot-pairing.md
+++ b/roles/osx/files/claude/commands/copilot-pairing.md
@@ -81,11 +81,30 @@ Order matters: land the code first, then talk about it. If we replied/resolved b
    - `git add` only the files we actually changed for this iteration (never `git add -A`).
    - Commit with a message of the form `chore(copilot): iter N, address <short summary>`.
    - Push: `git push origin <branch>`. **Never** `--force`, `--force-with-lease`, or any rebase flag.
-2. **Capture push timestamp** as a Unix epoch, used for both deadline math and the poll filter (substitute the PR number from pre-flight step 1):
+2. **Capture push timestamp and baseline Copilot-review id** (substitute the PR number from pre-flight step 1):
    ```bash
    date +%s > /tmp/copilot-pairing-push-epoch.NUMBER
+   gh api graphql -f query='
+     query($owner: String!, $repo: String!, $number: Int!) {
+       repository(owner: $owner, name: $repo) {
+         pullRequest(number: $number) {
+           reviews(last: 5) { nodes { id author { login } } }
+         }
+       }
+     }
+   ' -f owner='OWNER' -f repo='REPO' -F number=NUMBER \
+     | jq -r --arg bot 'copilot-pull-request-reviewer' '
+         .data.repository.pullRequest.reviews.nodes
+         | map(select(.author.login == $bot))
+         | last // empty
+         | .id // ""' \
+     > /tmp/copilot-pairing-baseline-review-id.NUMBER
    ```
-   The Bash tool spawns a fresh shell per invocation, so a plain shell variable will not be visible to the step (g) script. Use the temp file, or inline the literal value into the step (g) script when you send it. The filename is namespaced by PR number so concurrent pairing sessions on different PRs (e.g., separate worktrees) do not clobber each other's timestamps. We use epoch (not ISO-8601) so the poll filter can compare numerically via `fromdateiso8601` and avoid lexicographic edge cases at sub-second precision. This high-water mark is the floor for step (g)'s poll filter; capturing it any earlier risks matching a Copilot review that pre-dates this push.
+   The Bash tool spawns a fresh shell per invocation, so plain shell variables will not be visible to the step (g) script. Use the temp files, or inline the literal values into the step (g) script when you send it. Filenames are namespaced by PR number so concurrent pairing sessions on different PRs (e.g., separate worktrees) do not clobber each other.
+
+   We capture two values because step (g) needs both:
+   - **`push_epoch`** drives the 10-minute deadline math.
+   - **`baseline_review_id`** lets the poll match a *new* Copilot review unambiguously even when its `submittedAt` rounds down to the same second as `push_epoch`. Filtering on `submittedAt > push_epoch` alone misses same-second submissions (jq's `fromdateiso8601` is second-precision, and macOS `date` doesn't support sub-second `%N`). Filtering on `id != baseline_review_id` alone would re-match older Copilot reviews. Combining both (`submittedAt >= push_epoch AND id != baseline_review_id`) excludes pre-existing reviews and accepts same-second submissions. If there is no prior Copilot review, the baseline file holds the empty string and any non-empty review id passes.
 3. **Reply to threads** using `/copilot-review` step 8 mutations (multi-line GraphQL, body via temp file). **Use `addPullRequestReviewThreadReply` only**; see the DO-NOT-USE callout in `/copilot-review` step 8 about `addPullRequestReviewComment`. Reply body varies by classification, since this iteration may have a mix:
    - **`valid`**: short reply describing the change we made, ideally referencing the new commit SHA from (e.1).
    - **`already-handled`**: reply with `addressed in <commit-sha>` per Path B step 2, using the same `git log "$(gh pr view --json baseRefName -q '.baseRefName')..HEAD" --oneline -- <file>` lookup. Do not hardcode `main` as the base.
@@ -157,7 +176,7 @@ Inspect the response and branch:
 |---|---|---|
 | 2xx | n/a | Proceed to step (g). |
 | 422 | `already requested` (or similar "duplicate reviewer") | DELETE the reviewer, re-POST. Then proceed to step (g). |
-| 422 | `not a collaborator` | Pre-flight mode detection was wrong (the bot is no longer a Bot-typed reviewer). Log the mismatch and proceed to step (g). On the next run, re-check pre-flight step 3. |
+| 422 | `not a collaborator` | REST cannot request this reviewer. Possible causes: pre-flight mode detection was wrong (bot is App-typed), the bot lost collaborator status mid-run, or the login is otherwise ineligible. Log the outcome and proceed to step (g); the poll is the authoritative signal. Re-check pre-flight step 3 on the next run. |
 | Other (4xx/5xx) | n/a | Log warning. Proceed to step (g). |
 
 DELETE+POST retry pattern (only for the `already requested` case):
@@ -190,11 +209,12 @@ We need to wait up to **10 minutes** for a new Copilot review. Do not foreground
 **Preferred: a single backgrounded poll script** (`Bash` with `run_in_background=true`). The script polls itself and exits when the condition is met or the deadline passes. You'll be notified when it exits. Substitute the verified bot login from pre-flight step 3 in the `--arg bot ...` flag if it differs from the default.
 
 ```bash
-# Read push_epoch from the temp file written in step (e). Bash tool calls do
-# not share shell state, so reading from the file (or inlining the literal
-# value before sending the script) is required. File is namespaced by PR
-# number; substitute NUMBER from pre-flight step 1.
+# Read push_epoch and baseline_id from the temp files written in step (e).
+# Bash tool calls do not share shell state, so reading from the files (or
+# inlining the literal values before sending the script) is required. Files
+# are namespaced by PR number; substitute NUMBER from pre-flight step 1.
 push_epoch=$(cat /tmp/copilot-pairing-push-epoch.NUMBER 2>/dev/null)
+baseline_id=$(cat /tmp/copilot-pairing-baseline-review-id.NUMBER 2>/dev/null)
 [ -n "$push_epoch" ] || { echo "push_epoch not set; capture it in step (e) before running"; exit 2; }
 deadline=$(( push_epoch + 600 ))
 while [ $(date +%s) -lt $deadline ]; do
@@ -202,14 +222,18 @@ while [ $(date +%s) -lt $deadline ]; do
     query($owner: String!, $repo: String!, $number: Int!) {
       repository(owner: $owner, name: $repo) {
         pullRequest(number: $number) {
-          reviews(last: 5) { nodes { author { login } state submittedAt } }
+          reviews(last: 5) { nodes { id author { login } state submittedAt } }
         }
       }
     }
   ' -f owner='OWNER' -f repo='REPO' -F number=NUMBER \
-    | jq -r --arg bot 'copilot-pull-request-reviewer' --argjson since "$push_epoch" '
+    | jq -r --arg bot 'copilot-pull-request-reviewer' --arg baseline "$baseline_id" --argjson since "$push_epoch" '
         .data.repository.pullRequest.reviews.nodes
-        | map(select(.author.login == $bot and (.submittedAt | sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601) > $since))
+        | map(select(
+            .author.login == $bot
+            and .id != $baseline
+            and (.submittedAt | sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601) >= $since
+          ))
         | last // empty')
   if [ -n "$latest" ]; then echo "NEW_REVIEW $latest"; exit 0; fi
   sleep 30
@@ -224,14 +248,19 @@ Branch on the script's exit:
 - **Exit 0 (`NEW_REVIEW`)**: re-fetch reviewThreads. If any are unresolved, increment iteration counter and loop back to (a). If zero unresolved, success: exit the loop.
 - **Exit 1 (`TIMEOUT`)**: trigger the **No response** stop condition.
 - **Exit 2 (bad input)**: step (e) failed to capture `push_epoch`. Bug in our flow. Stop and surface the script's stderr.
-- **Any other exit code (e.g. 143 from SIGTERM, 137 from SIGKILL/OOM, or any 128+N signal exit from a harness session end)**: the script was killed externally; its output is not authoritative. Re-query GraphQL directly, reading `push_epoch` from `/tmp/copilot-pairing-push-epoch.NUMBER` for both the deadline check and the poll filter:
+- **Any other exit code (e.g. 143 from SIGTERM, 137 from SIGKILL/OOM, or any 128+N signal exit from a harness session end)**: the script was killed externally; its output is not authoritative. Re-query GraphQL directly, reading `push_epoch` and `baseline_id` from the temp files:
   ```bash
   push_epoch=$(cat /tmp/copilot-pairing-push-epoch.NUMBER)
+  baseline_id=$(cat /tmp/copilot-pairing-baseline-review-id.NUMBER)
   gh api graphql -f query='...same as the poll script...' \
     -f owner='OWNER' -f repo='REPO' -F number=NUMBER \
-    | jq --arg bot 'copilot-pull-request-reviewer' --argjson since "$push_epoch" '
+    | jq --arg bot 'copilot-pull-request-reviewer' --arg baseline "$baseline_id" --argjson since "$push_epoch" '
         .data.repository.pullRequest.reviews.nodes
-        | map(select(.author.login == $bot and (.submittedAt | sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601) > $since))'
+        | map(select(
+            .author.login == $bot
+            and .id != $baseline
+            and (.submittedAt | sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601) >= $since
+          ))'
   ```
   - **New Copilot review found**: treat as `NEW_REVIEW` and proceed as above.
   - **No new review, still inside the 10-minute window** (`[ $(date +%s) -lt $((push_epoch + 600)) ]`): restart the background poll script. Cap restarts at **2** per iteration to prevent thrashing; after that, treat as **No response**.

--- a/roles/osx/files/claude/commands/copilot-pairing.md
+++ b/roles/osx/files/claude/commands/copilot-pairing.md
@@ -34,7 +34,7 @@ For each iteration (cap = **10**):
 
 ### a. Fetch Copilot's open threads
 
-Use the same GraphQL query as `/copilot-review` step 3. Filter to threads where `isResolved: false` AND first comment author login == Copilot bot login. If a thread's first comment was created before the last commit SHA we pushed, skip it (it predates the latest review and may be stale).
+Use the same GraphQL query as `/copilot-review` step 3. Filter to threads where `isResolved: false` AND first comment author login == Copilot bot login. Do not add a "skip if older than last push" filter: `isResolved: false` is the canonical signal. If a previous iteration's resolve mutation failed silently, we want this loop to retry it, not skip it. Re-processing an already-fixed thread is safe (passes will classify it as no-op / already-handled and the resolve mutation re-fires).
 
 ### b. Validate every thread (strict, three passes minimum)
 

--- a/roles/osx/files/claude/commands/copilot-pairing.md
+++ b/roles/osx/files/claude/commands/copilot-pairing.md
@@ -107,7 +107,7 @@ mcp__<github-server>__request_copilot_review
 params: { owner, repo, pullNumber }
 ```
 
-The substitute for `<github-server>` depends on the active MCP server (e.g. `claude_ai_Github-Symmetry`, `claude_ai_Github-Gusto`). The REST endpoint `POST /repos/{owner}/{repo}/pulls/{n}/requested_reviewers` returns 422 "not a collaborator" for Bot reviewers and must NOT be used in app mode; the MCP tool wraps an internal Copilot-review-request endpoint that accepts Bot reviewers. If no `request_copilot_review` MCP tool is available on the active server, stop with **No response** and report; do not assume push alone will trigger a review.
+The substitute for `<github-server>` depends on the active MCP server (e.g. `claude_ai_Github-Symmetry`, `claude_ai_Github-Gusto`). The REST endpoint `POST /repos/{owner}/{repo}/pulls/{n}/requested_reviewers` returns 422 "not a collaborator" for Bot reviewers and must NOT be used in app mode; the MCP tool wraps an internal Copilot-review-request endpoint that accepts Bot reviewers. If no `request_copilot_review` MCP tool is available on the active server, stop with **Re-review unavailable** and report; do not assume push alone will trigger a review.
 
 After the MCP call returns success, **verify** Copilot is actually on the requested-reviewer list:
 
@@ -145,10 +145,10 @@ Inspect the response and branch:
 
 | Outcome | Body contains | Action |
 |---|---|---|
-| 2xx | — | Proceed to step (g). |
+| 2xx | n/a | Proceed to step (g). |
 | 422 | `already requested` (or similar "duplicate reviewer") | DELETE the reviewer, re-POST. Then proceed to step (g). |
 | 422 | `not a collaborator` | Pre-flight mode detection was wrong (the bot is no longer a Bot-typed reviewer). Log the mismatch and proceed to step (g). On the next run, re-check pre-flight step 3. |
-| Other (4xx/5xx) | — | Log warning. Proceed to step (g). |
+| Other (4xx/5xx) | n/a | Log warning. Proceed to step (g). |
 
 DELETE+POST retry pattern (only for the `already requested` case):
 
@@ -256,7 +256,8 @@ If any condition fires, **stop**. Print the latest iteration table, name the con
 | **Iteration cap** | 10 iterations completed without convergence. Stop and report. |
 | **Cannot reproduce** | Issue is not reproducible and the proposed fix is non-trivial. |
 | **Migrations / data / destructive ops** | Schema migrations, data backfills, deletes, drops, or anything irreversible. Always human-driven. |
-| **No response** | 10-minute poll window expires with no new Copilot review. |
+| **No response** | 10-minute poll window in step (g) expires with no new Copilot review. |
+| **Re-review unavailable** | Step (f) `app` mode found no `request_copilot_review` MCP tool on the active server, so we cannot trigger a Copilot review and step (g)'s poll would never see one. |
 | **Pending reply unsubmittable** | A pending review owned by the viewer cannot be submitted via `submitPullRequestReview` in step (e.4), so replies posted in (e.3) would remain invisible to GitHub, Copilot, and humans. |
 | **Conflicting signals** | Copilot's later review contradicts an earlier one we already addressed. Pause to decide which to honor. |
 

--- a/roles/osx/files/claude/commands/copilot-pairing.md
+++ b/roles/osx/files/claude/commands/copilot-pairing.md
@@ -68,9 +68,9 @@ Run whatever the project ships for local verification: tests, linters, type chec
 ### e. Reply, resolve, commit, push
 
 - Reply to and resolve every thread using `/copilot-review` step 8 mutations (multi-line GraphQL, body via temp file).
-- `git add` only the files we actually changed for this iteration. Never `git add -A`.
-- Commit with a message of the form: `chore(copilot): iter N, address <short summary>`.
-- Push: `git push origin <branch>`. **Never** `--force`, `--force-with-lease`, or any rebase flag.
+- If this iteration produced **no code changes** (every thread was classified `already-handled` and we only re-fired the resolves), skip the commit / push and go to step (f.5) below: do not re-request review against an unchanged HEAD, since Copilot will not respond and step (g) will time out.
+- Otherwise: `git add` only the files we actually changed for this iteration (never `git add -A`). Commit with a message of the form `chore(copilot): iter N, address <short summary>`. Push: `git push origin <branch>`. **Never** `--force`, `--force-with-lease`, or any rebase flag.
+- Immediately after the push completes, capture `push_ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)`. This is the high-water mark used by step (g)'s poll filter; capturing it any earlier risks matching a Copilot review that pre-dates this iteration's push.
 
 ### f. Re-request Copilot review
 
@@ -81,14 +81,26 @@ gh api -X POST "repos/OWNER/REPO/pulls/NUMBER/requested_reviewers" \
   -f 'reviewers[]=copilot-pull-request-reviewer'
 ```
 
-If the request returns 422 because Copilot is already a requested reviewer, first remove it then re-add:
+If the request returns 422 because Copilot is already a requested reviewer, remove it then re-run the POST:
 
 ```bash
 gh api -X DELETE "repos/OWNER/REPO/pulls/NUMBER/requested_reviewers" \
   -f 'reviewers[]=copilot-pull-request-reviewer'
+
+gh api -X POST "repos/OWNER/REPO/pulls/NUMBER/requested_reviewers" \
+  -f 'reviewers[]=copilot-pull-request-reviewer'
 ```
 
 **First-run verification.** This re-request path has not been live-tested for every account / repo combination. On iteration 1, after firing the POST, confirm: (a) the call returned 2xx, and (b) Copilot actually starts a new review (visible in step (g)'s poll). If either fails, trigger the **No response** stop condition and hand back to me; do not blindly continue looping.
+
+### f.5. Resolve-only iteration short-circuit
+
+Only reached if step (e) produced no commits. Re-fetch reviewThreads (same query as step (a)) and count unresolved Copilot threads:
+
+- **Zero remaining**: success. Exit the loop. Print the iteration summary noting "resolve-only iteration, no new code, all Copilot threads now resolved".
+- **One or more remaining** (rare: a resolve mutation failed again): increment iteration counter and loop back to step (a). If the same threads remain unresolved across two consecutive iterations, trigger the **Loop detection** stop condition.
+
+Skip step (g) entirely on this path.
 
 ### g. Wait for Copilot's response
 
@@ -97,7 +109,9 @@ We need to wait up to **10 minutes** for a new Copilot review. Do not foreground
 **Preferred: a single backgrounded poll script** (`Bash` with `run_in_background=true`). The script polls itself and exits when the condition is met or the deadline passes. You'll be notified when it exits.
 
 ```bash
-push_ts='ITERATION_PUSH_ISO8601'   # the push time from step (e)
+# `push_ts` must already be set in this shell from step (e)'s capture.
+# Sanity check; abort rather than silently using an empty filter:
+[ -n "$push_ts" ] || { echo "push_ts not set; capture it in step (e) before running"; exit 2; }
 deadline=$(( $(date +%s) + 600 ))
 while [ $(date +%s) -lt $deadline ]; do
   latest=$(gh api graphql -f query='

--- a/roles/osx/files/claude/commands/copilot-pairing.md
+++ b/roles/osx/files/claude/commands/copilot-pairing.md
@@ -47,12 +47,12 @@ Be more conservative than in `/copilot-review` because nobody is checking our wo
 - If the fix would touch a file outside the PR's existing diff, trigger **Scope creep**.
 - Apply the same three-pass rigor to every proposed fix. Do not trust Copilot's recommendation; design our own from first principles, then validate it from three angles before accepting.
 
-### c. Implement valid items — solution validated with two or three test angles
+### c. Implement valid items: solution validated with two or three test angles
 
 Apply `/copilot-review` step 6 (canonical rigor in CLAUDE.md `Validation Rigor (Solutions)`):
 
 1. **Targeted test.** Write a failing test for the bug's exact reason, confirm it fails for the right reason, apply the fix, confirm it now passes.
-2. **Wider check.** Run the broader project test suite, linters, type-checkers. Any regression — even in unrelated areas — triggers the **Test failure** stop condition.
+2. **Wider check.** Run the broader project test suite, linters, type-checkers. Any regression (even in unrelated areas) triggers the **Test failure** stop condition.
 3. **Edge / integration / manual** (when relevant). Boundary cases, integration or smoke tests, manual exercise of the user-facing flow.
 
 Skip the targeted-test step only for non-behavioral changes (docs, comments, pure renames, formatting). For those, substitute review angles per the canonical doctrine.
@@ -61,13 +61,13 @@ For **false positives**, draft the dismissal reply (citing the three passes) but
 
 ### d. Run the full local check suite
 
-Run whatever the project ships for local verification: tests, linters, type checkers, formatters. Common entry points: `npm test`, `pytest`, `go test ./...`, `cargo test`, `bundle exec rspec`, `mise run test`, `lefthook run pre-commit`. If the project has a single canonical command, prefer it. If anything fails — even a pre-existing failure unrelated to our changes — trigger the **Test failure** stop condition.
+Run whatever the project ships for local verification: tests, linters, type checkers, formatters. Common entry points: `npm test`, `pytest`, `go test ./...`, `cargo test`, `bundle exec rspec`, `mise run test`, `lefthook run pre-commit`. If the project has a single canonical command, prefer it. If anything fails (even a pre-existing failure unrelated to our changes), trigger the **Test failure** stop condition.
 
 ### e. Reply, resolve, commit, push
 
-- Reply to and resolve every thread using `/copilot-review` step 9 mutations (multi-line GraphQL, body via temp file).
+- Reply to and resolve every thread using `/copilot-review` step 8 mutations (multi-line GraphQL, body via temp file).
 - `git add` only the files we actually changed for this iteration. Never `git add -A`.
-- Commit with a message of the form: `chore(copilot): iter N — address <short summary>`.
+- Commit with a message of the form: `chore(copilot): iter N, address <short summary>`.
 - Push: `git push origin <branch>`. **Never** `--force`, `--force-with-lease`, or any rebase flag.
 
 ### f. Re-request Copilot review
@@ -85,6 +85,8 @@ If the request returns 422 because Copilot is already a requested reviewer, firs
 gh api -X DELETE "repos/OWNER/REPO/pulls/NUMBER/requested_reviewers" \
   -f 'reviewers[]=copilot-pull-request-reviewer'
 ```
+
+**First-run verification.** This re-request path has not been live-tested for every account / repo combination. On iteration 1, after firing the POST, confirm: (a) the call returned 2xx, and (b) Copilot actually starts a new review (visible in step (g)'s poll). If either fails, trigger the **No response** stop condition and hand back to me; do not blindly continue looping.
 
 ### g. Wait for Copilot's response
 
@@ -107,7 +109,7 @@ gh api graphql -f query='
 A new Copilot review is one where `author.login == bot login` and `submittedAt > our iteration's push timestamp`.
 
 After the new review appears, re-fetch reviewThreads and compare against the baseline:
-- **Zero new unresolved Copilot threads**: success — exit the loop.
+- **Zero new unresolved Copilot threads**: success. Exit the loop.
 - **One or more new threads**: increment iteration counter and loop back to (a).
 
 If the 10-minute poll window expires with no new Copilot review, trigger the **No response** stop condition.
@@ -132,9 +134,9 @@ If any condition fires, **stop**. Print the latest iteration table, name the con
 | **Ambiguity** | Comment is unclear, has multiple valid interpretations, or requires a product/UX call. |
 | **Loop detection** | Copilot raised a substantively similar concern (same file, same root issue) in two consecutive iterations. |
 | **Scope creep** | A fix would touch code outside the PR's existing diff, or contradicts the PR's stated intent / Jira AC. |
-| **Test failure** | Any test, linter, type-check, or formatter fails after our change — including pre-existing failures we surface for the first time. |
+| **Test failure** | Any test, linter, type-check, or formatter fails after our change, including pre-existing failures we surface for the first time. |
 | **Security-sensitive** | The change touches auth, secrets handling, crypto, permissions, IAM, SQL/shell construction, or sandbox boundaries. Always pause. |
-| **High false-positive ratio** | More than half of an iteration's threads are false positives — model may be misreading the change. Pause for re-alignment. |
+| **High false-positive ratio** | More than half of an iteration's threads are false positives (model may be misreading the change). Pause for re-alignment. |
 | **Iteration cap** | 10 iterations completed without convergence. Stop and report. |
 | **Cannot reproduce** | Issue is not reproducible and the proposed fix is non-trivial. |
 | **Migrations / data / destructive ops** | Schema migrations, data backfills, deletes, drops, or anything irreversible. Always human-driven. |
@@ -148,7 +150,7 @@ These hold at every step:
 - **Never** amend, squash, or rebase commits already pushed.
 - **Never** dismiss a thread without an explanatory reply.
 - **Never** skip the failing-test-first step on a behavior-changing fix.
-- **Never** commit or touch files outside the PR's diff to "fix" something we noticed in passing — surface it as an adjacent finding for human review instead.
+- **Never** commit or touch files outside the PR's diff to "fix" something we noticed in passing. Surface it as an adjacent finding for human review instead.
 - **Never** modify CI configuration, `.env`, secrets, or lockfiles unless the Copilot thread is specifically about that file.
 - **Never** post anything to chat platforms or tickets.
 

--- a/roles/osx/files/claude/commands/copilot-review.md
+++ b/roles/osx/files/claude/commands/copilot-review.md
@@ -97,6 +97,8 @@ After all items are addressed, commit the changes and push.
 
 ### 8. Reply to and resolve each thread
 
+**Use `addPullRequestReviewThreadReply` only.** Do **NOT** use `addPullRequestReviewComment` (with or without `inReplyTo`) for this workflow. `addPullRequestReviewComment` builds up a *pending* review that must be submitted via a separate `submitPullRequestReview` mutation, and replies posted that way silently sit as drafts until someone clicks Submit. This has bitten this skill before. The right mutation for replying to an existing review thread is `addPullRequestReviewThreadReply`, which posts the reply immediately, no submit step required.
+
 **Shell quoting rules:**
 - Always use multi-line query strings for GraphQL mutations. Single-line strings cause the shell to eat `$` in variable names like `$threadId`.
 - Always write the response body to a temp file and use `-F body=@file` to pass it. This avoids fish shell interpreting backticks in the body as command substitution.

--- a/roles/osx/files/claude/commands/copilot-review.md
+++ b/roles/osx/files/claude/commands/copilot-review.md
@@ -33,7 +33,7 @@ gh api graphql -f query='
               nodes {
                 id
                 body
-                author { login }
+                author { __typename login }
                 createdAt
               }
             }
@@ -45,25 +45,51 @@ gh api graphql -f query='
 ' -f owner='OWNER' -f repo='REPO' -F number=NUMBER
 ```
 
-### 4. Validate each unresolved thread
+Filter to threads where `isResolved: false` AND the first comment author login is `copilot-pull-request-reviewer` (the Copilot bot). If the PR has threads from other authors too, leave those for `/peer-review`.
 
-Filter to only unresolved threads (`isResolved: false`). For each one:
+### 4. Validate every thread — three passes minimum (different angle each)
 
-- Read the comment body and identify the referenced file path and line(s)
-- Read the actual source code at that location
-- **Validate thoroughly**: Determine if the concern is legitimate by checking the real code. Copilot often produces false positives.
-- Classify as: **valid** (needs a fix), **false positive**, or **low-confidence**
+Apply the canonical rigor in CLAUDE.md `Validation Rigor (Issue Identification)`. For each unresolved Copilot thread:
 
-### 5. Present the validated list
+- **Read first.** Comment body, referenced file:line, plus enough surrounding context (callers, related modules) to understand the real behavior.
+- **Pass 1: direct reproduction.** When the claim is about runtime behavior, try to reproduce it. Write a failing test, run a script, trace through the code with concrete inputs, or construct an input that triggers the claimed bug. Inability to reproduce is a strong signal of a false positive.
+- **Pass 2: orthogonal angle.** Look at it from a different perspective: callers and what they assume, related code paths and side effects, hidden invariants, project conventions, sibling implementations, existing test coverage that may already prove the case safe.
+- **Pass 3: outside-in angle.** Sources outside the diff. `git log` / `git blame` for the why-it-is-the-way-it-is. Repo-wide search for similar patterns to see if the concern applies elsewhere or only here. For text/research-based claims (API correctness, spec compliance, deprecated patterns, security claims, library behavior): official docs, the library's own source/tests, deepwiki MCP, GitHub issues, RFCs, web search. Note what was consulted.
 
-Show all threads with their classifications. Emphasize false positives so I can see what was caught. Include the thread ID for each item.
+**Do not take Copilot's recommendation as correct.** Even when the underlying concern is real, design the best solution from first principles. Copilot's suggested fix may be insufficient (treating a symptom not the cause), wrong (introduces a new bug), unidiomatic for the codebase, or out of scope. Apply the same three-pass rigor to the proposed fix: does it actually resolve the issue, does it survive an orthogonal angle, does it match what docs/conventions/external references would recommend.
 
-### 6. Address items
+Classify each thread as **valid** (needs a fix), **false positive** (no real problem), or **low-confidence** (passes did not converge — never guess). Look for issues Copilot did not flag that are adjacent to what it did. Surface those as extra rows tagged "adjacent finding".
+
+### 5. Present the validated table
+
+Output one Markdown table. Default columns:
+
+| # | Thread ID | File:Line | Copilot's concern | What we found | Reproduced? | Classification | Confidence | Our proposed fix |
+
+Notes on columns:
+- **Copilot's concern**: a tight one-line summary of what the bot said, not a copy-paste.
+- **What we found**: the result of our investigation (the actual behavior, the real root cause, or "no issue, code already handles X").
+- **Reproduced?**: `yes` / `no` / `n/a` (n/a for items not reproducible by their nature, e.g. style/naming).
+- **Classification**: `valid` / `false positive` / `low-confidence` / `adjacent finding`.
+- **Confidence**: `high` / `medium` / `low` — how sure we are about the classification.
+- **Our proposed fix**: a one-line description of the change we want to make. May explicitly differ from Copilot's suggestion.
+
+If a column is not useful for the current PR (or you want a different cut), say so before printing the table and adjust. Optional add-ons worth considering case by case: `Severity`, `Test plan`, `Copilot's suggested fix` (when it diverges meaningfully from ours), `Files touched by fix`, `Scope risk` (in-scope / out-of-scope).
+
+### 6. Address items — solution validated with two or three test angles
 
 Follow the standard review workflow (let me choose: all at once or one by one, with progress tracking).
 
-For false positives: prepare a brief dismissal comment.
-For valid items: fix the code and prepare a comment explaining the change.
+For **valid** items that affect runtime behavior, apply the canonical rigor in CLAUDE.md `Validation Rigor (Solutions)`:
+
+1. **Targeted test.** Write a test that demonstrates the bug. Run it and confirm it fails for the expected reason — not for an unrelated reason like a missing import. Apply the fix. Re-run the test and confirm it now passes.
+2. **Wider check.** Run the broader project test suite, linters, and type-checkers. Watch for regressions, including in code paths the fix did not directly touch.
+3. **Edge / integration / manual** (when relevant). Boundary cases (null, empty, max size, concurrency), an integration or smoke test, or manual exercise of the user-facing flow.
+
+"When applicable" means: skip targeted-test for non-behavioral changes (doc-only fixes, comment changes, pure renames, type-only adjustments, formatting). For those, substitute review angles per the canonical doctrine: re-read the diff, read it from each caller's perspective, grep for places the change could silently break. Note in the reply why no test was added.
+
+For **false positives**: prepare a brief dismissal comment explaining what we checked (cite the three passes) and why the concern does not apply.
+For **low-confidence**: pause and ask me before taking action.
 
 ### 7. Commit and push
 
@@ -109,6 +135,6 @@ gh api graphql -f query='
 
 ## Maintenance
 
-After completing the workflow, check if any part of these instructions seem outdated, incorrect, or misaligned with the current project's tooling or workflow (e.g., GraphQL schema changes, deprecated fields, new `gh` CLI capabilities). If something looks off, flag it and offer a ready-to-use prompt I can paste into a new dotfiles session to update this command.
+After completing the workflow, check if any part of these instructions seem outdated, incorrect, or misaligned with the current project's tooling or workflow (e.g., GraphQL schema changes, deprecated fields, new `gh` CLI capabilities, Copilot bot login changes). If something looks off, flag it and offer a ready-to-use prompt I can paste into a new dotfiles session to update this command.
 
 $ARGUMENTS

--- a/roles/osx/files/claude/commands/copilot-review.md
+++ b/roles/osx/files/claude/commands/copilot-review.md
@@ -61,10 +61,10 @@ gh api graphql -f query='
 
 Use the actual `Bot` login if it differs. If the PR has threads from other authors too, leave those for `/peer-review`.
 
-Concretely, pipe the reviewThreads response into jq (substitute the verified bot login if it isn't the default):
+Pipe the previous query's output through this jq filter (substitute the verified bot login if it isn't the default):
 
 ```bash
-| jq --arg bot 'copilot-pull-request-reviewer' '
+jq --arg bot 'copilot-pull-request-reviewer' '
     .data.repository.pullRequest.reviewThreads.nodes
     | map(select(.isResolved == false and .comments.nodes[0].author.login == $bot))'
 ```

--- a/roles/osx/files/claude/commands/copilot-review.md
+++ b/roles/osx/files/claude/commands/copilot-review.md
@@ -45,14 +45,14 @@ gh api graphql -f query='
 ' -f owner='OWNER' -f repo='REPO' -F number=NUMBER
 ```
 
-Filter to threads where `isResolved: false` AND the first comment author is the Copilot bot. The standard bot login is `copilot-pull-request-reviewer` (`__typename: Bot`), but verify per run, especially on GHES or repos with custom bot integrations:
+Filter to threads where `isResolved: false` AND the first comment author is the Copilot bot. The standard bot login is `copilot-pull-request-reviewer` (`__typename: Bot`), but verify per run, especially on GHES or repos with custom bot integrations. Use `reviews(last: 5)` so the query surfaces the most-recent reviews; `first: 5` would return the oldest and may not include Copilot on a long-lived PR:
 
 ```bash
 gh api graphql -f query='
   query($owner: String!, $repo: String!, $number: Int!) {
     repository(owner: $owner, name: $repo) {
       pullRequest(number: $number) {
-        reviews(first: 5) { nodes { author { __typename login } } }
+        reviews(last: 5) { nodes { author { __typename login } } }
       }
     }
   }
@@ -89,6 +89,7 @@ Classify each thread as **valid** (needs a fix), **false positive** (no real pro
 Output one Markdown table. Default columns:
 
 | # | Thread ID | File:Line | Copilot's concern | What we found | Reproduced? | Classification | Confidence | Our proposed fix |
+|---|---|---|---|---|---|---|---|---|
 
 Notes on columns:
 - **Copilot's concern**: a tight one-line summary of what the bot said, not a copy-paste.

--- a/roles/osx/files/claude/commands/copilot-review.md
+++ b/roles/osx/files/claude/commands/copilot-review.md
@@ -45,7 +45,21 @@ gh api graphql -f query='
 ' -f owner='OWNER' -f repo='REPO' -F number=NUMBER
 ```
 
-Filter to threads where `isResolved: false` AND the first comment author login is `copilot-pull-request-reviewer` (the Copilot bot). If the PR has threads from other authors too, leave those for `/peer-review`.
+Filter to threads where `isResolved: false` AND the first comment author is the Copilot bot. The standard bot login is `copilot-pull-request-reviewer` (`__typename: Bot`), but verify per run, especially on GHES or repos with custom bot integrations:
+
+```bash
+gh api graphql -f query='
+  query($owner: String!, $repo: String!, $number: Int!) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $number) {
+        reviews(first: 5) { nodes { author { __typename login } } }
+      }
+    }
+  }
+' -f owner='OWNER' -f repo='REPO' -F number=NUMBER
+```
+
+Use the actual `Bot` login if it differs. If the PR has threads from other authors too, leave those for `/peer-review`.
 
 ### 4. Validate every thread: three passes minimum (different angle each)
 

--- a/roles/osx/files/claude/commands/copilot-review.md
+++ b/roles/osx/files/claude/commands/copilot-review.md
@@ -121,13 +121,20 @@ After all items are addressed, commit the changes and push.
 
 ### 8. Reply to and resolve each thread
 
-**Use `addPullRequestReviewThreadReply` only.** Do **NOT** use `addPullRequestReviewComment` (with or without `inReplyTo`) for this workflow. `addPullRequestReviewComment` builds up a *pending* review that must be submitted via a separate `submitPullRequestReview` mutation, and replies posted that way silently sit as drafts until someone clicks Submit. This has bitten this skill before. The right mutation for replying to an existing review thread is `addPullRequestReviewThreadReply`, which posts the reply immediately, no submit step required.
+**Use `addPullRequestReviewThreadReply` only.** Do **NOT** use `addPullRequestReviewComment` (with or without `inReplyTo`) for this workflow.
+
+Both mutations can leave replies invisible by attaching them to a *pending* review owned by the viewer:
+
+- `addPullRequestReviewComment` always builds onto a review and creates a pending one if none is in progress. This has bitten this skill before; replies sat as drafts until someone manually clicked Submit.
+- `addPullRequestReviewThreadReply` is the more direct mutation, but per a 2026-05-02 live-run failure on `SymmetrySoftware/stl-poc#13` it can also auto-vivify a pending review when the viewer has none in progress. The reply then stays invisible (to the GitHub UI, to Copilot, to humans) until the pending review is submitted.
+
+After the batch of replies, **always** submit any pending review you own on this PR before resolving threads (see "Submit any auto-vivified pending review" below). A successful-looking run can otherwise complete with all replies silently invisible.
 
 **Shell quoting rules:**
 - Always use multi-line query strings for GraphQL mutations. Single-line strings cause the shell to eat `$` in variable names like `$threadId`.
 - Always write the response body to a temp file and use `-F body=@file` to pass it. This avoids fish shell interpreting backticks in the body as command substitution.
 
-For each thread, run both mutations in sequence:
+For each thread, run the reply mutation. After the whole batch of replies, run the pending-review submit step **once**, then run the resolve mutation per thread.
 
 **Reply to the thread** (use the thread `id` from step 3, not the comment id):
 
@@ -144,6 +151,42 @@ gh api graphql -f query='
   }
 ' -f threadId='THREAD_ID' -F body=@/tmp/gh-review-comment.txt
 ```
+
+**Submit any auto-vivified pending review** (run once after all replies are posted, before resolving):
+
+Query the PR's pending reviews and the viewer's login in one round-trip, then submit each pending review owned by the viewer:
+
+```bash
+gh api graphql -f query='
+  query($owner: String!, $repo: String!, $number: Int!) {
+    viewer { login }
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $number) {
+        reviews(states: PENDING, first: 10) {
+          nodes { id author { login } }
+        }
+      }
+    }
+  }
+' -f owner='OWNER' -f repo='REPO' -F number=NUMBER
+```
+
+For each `reviews.nodes` entry where `author.login == viewer.login`:
+
+```bash
+gh api graphql -f query='
+  mutation($id: ID!) {
+    submitPullRequestReview(input: {
+      pullRequestReviewId: $id,
+      event: COMMENT
+    }) {
+      pullRequestReview { id state submittedAt }
+    }
+  }
+' -f id='REVIEW_ID'
+```
+
+Re-run the pending-reviews query and assert no pending reviews owned by the viewer remain. If a pending review cannot be submitted, stop and surface the error rather than silently resolving threads on top of invisible replies.
 
 **Resolve the thread:**
 

--- a/roles/osx/files/claude/commands/copilot-review.md
+++ b/roles/osx/files/claude/commands/copilot-review.md
@@ -61,6 +61,16 @@ gh api graphql -f query='
 
 Use the actual `Bot` login if it differs. If the PR has threads from other authors too, leave those for `/peer-review`.
 
+Concretely, pipe the reviewThreads response into jq (substitute the verified bot login if it isn't the default):
+
+```bash
+| jq --arg bot 'copilot-pull-request-reviewer' '
+    .data.repository.pullRequest.reviewThreads.nodes
+    | map(select(.isResolved == false and .comments.nodes[0].author.login == $bot))'
+```
+
+Filter on `login` rather than `__typename == "Bot"` so other bot integrations (CodeQL, Dependabot review, etc.) don't get pulled in.
+
 ### 4. Validate every thread: three passes minimum (different angle each)
 
 Apply the canonical rigor in CLAUDE.md `Validation Rigor (Issue Identification)`. For each unresolved Copilot thread:

--- a/roles/osx/files/claude/commands/copilot-review.md
+++ b/roles/osx/files/claude/commands/copilot-review.md
@@ -47,7 +47,7 @@ gh api graphql -f query='
 
 Filter to threads where `isResolved: false` AND the first comment author login is `copilot-pull-request-reviewer` (the Copilot bot). If the PR has threads from other authors too, leave those for `/peer-review`.
 
-### 4. Validate every thread — three passes minimum (different angle each)
+### 4. Validate every thread: three passes minimum (different angle each)
 
 Apply the canonical rigor in CLAUDE.md `Validation Rigor (Issue Identification)`. For each unresolved Copilot thread:
 
@@ -58,7 +58,7 @@ Apply the canonical rigor in CLAUDE.md `Validation Rigor (Issue Identification)`
 
 **Do not take Copilot's recommendation as correct.** Even when the underlying concern is real, design the best solution from first principles. Copilot's suggested fix may be insufficient (treating a symptom not the cause), wrong (introduces a new bug), unidiomatic for the codebase, or out of scope. Apply the same three-pass rigor to the proposed fix: does it actually resolve the issue, does it survive an orthogonal angle, does it match what docs/conventions/external references would recommend.
 
-Classify each thread as **valid** (needs a fix), **false positive** (no real problem), or **low-confidence** (passes did not converge — never guess). Look for issues Copilot did not flag that are adjacent to what it did. Surface those as extra rows tagged "adjacent finding".
+Classify each thread as **valid** (needs a fix), **false positive** (no real problem), or **low-confidence** (passes did not converge; never guess). Look for issues Copilot did not flag that are adjacent to what it did. Surface those as extra rows tagged "adjacent finding".
 
 ### 5. Present the validated table
 
@@ -71,18 +71,18 @@ Notes on columns:
 - **What we found**: the result of our investigation (the actual behavior, the real root cause, or "no issue, code already handles X").
 - **Reproduced?**: `yes` / `no` / `n/a` (n/a for items not reproducible by their nature, e.g. style/naming).
 - **Classification**: `valid` / `false positive` / `low-confidence` / `adjacent finding`.
-- **Confidence**: `high` / `medium` / `low` — how sure we are about the classification.
+- **Confidence**: `high` / `medium` / `low`. How sure we are about the classification.
 - **Our proposed fix**: a one-line description of the change we want to make. May explicitly differ from Copilot's suggestion.
 
 If a column is not useful for the current PR (or you want a different cut), say so before printing the table and adjust. Optional add-ons worth considering case by case: `Severity`, `Test plan`, `Copilot's suggested fix` (when it diverges meaningfully from ours), `Files touched by fix`, `Scope risk` (in-scope / out-of-scope).
 
-### 6. Address items — solution validated with two or three test angles
+### 6. Address items: solution validated with two or three test angles
 
 Follow the standard review workflow (let me choose: all at once or one by one, with progress tracking).
 
 For **valid** items that affect runtime behavior, apply the canonical rigor in CLAUDE.md `Validation Rigor (Solutions)`:
 
-1. **Targeted test.** Write a test that demonstrates the bug. Run it and confirm it fails for the expected reason — not for an unrelated reason like a missing import. Apply the fix. Re-run the test and confirm it now passes.
+1. **Targeted test.** Write a test that demonstrates the bug. Run it and confirm it fails for the expected reason (not for an unrelated reason like a missing import). Apply the fix. Re-run the test and confirm it now passes.
 2. **Wider check.** Run the broader project test suite, linters, and type-checkers. Watch for regressions, including in code paths the fix did not directly touch.
 3. **Edge / integration / manual** (when relevant). Boundary cases (null, empty, max size, concurrency), an integration or smoke test, or manual exercise of the user-facing flow.
 

--- a/roles/osx/files/claude/commands/copilot-review.md
+++ b/roles/osx/files/claude/commands/copilot-review.md
@@ -61,7 +61,7 @@ gh api graphql -f query='
 
 Use the actual `Bot` login if it differs. If the PR has threads from other authors too, leave those for `/peer-review`.
 
-Pipe the previous query's output through this jq filter (substitute the verified bot login if it isn't the default):
+Apply this jq filter to the **`reviewThreads` query output** (the first GraphQL block in this step, not the `reviews(last: 5)` bot-login verification block) (substitute the verified bot login if it isn't the default):
 
 ```bash
 jq --arg bot 'copilot-pull-request-reviewer' '

--- a/roles/osx/files/claude/commands/peer-review.md
+++ b/roles/osx/files/claude/commands/peer-review.md
@@ -35,7 +35,7 @@ gh api graphql -f query='
               nodes {
                 id
                 body
-                author { login }
+                author { __typename login }
                 createdAt
               }
             }
@@ -49,7 +49,7 @@ gh api graphql -f query='
 
 ### 4. Validate each unresolved thread: three passes minimum (different angle each)
 
-Filter to only unresolved threads (`isResolved: false`). For each one, apply the canonical rigor in CLAUDE.md `Validation Rigor (Issue Identification)`:
+Filter to threads where `isResolved: false` AND the first comment author is NOT a `Bot` (`__typename != "Bot"`). Bot threads (Copilot and friends) belong to `/copilot-review` or `/copilot-pairing`; processing them here would generate human-tone replies to a bot. For each remaining thread, apply the canonical rigor in CLAUDE.md `Validation Rigor (Issue Identification)`:
 
 - **Read first.** The full comment thread (all comments, not just the first), the actual source at the referenced location, and the reviewer's likely intent.
 - **Pass 1: direct reproduction.** When the concern is about runtime behavior, reproduce it. Failing test, repro script, trace through the code with concrete inputs. Inability to reproduce is a strong signal it may be a preference or a false positive.

--- a/roles/osx/files/claude/commands/peer-review.md
+++ b/roles/osx/files/claude/commands/peer-review.md
@@ -47,7 +47,7 @@ gh api graphql -f query='
 ' -f owner='OWNER' -f repo='REPO' -F number=NUMBER
 ```
 
-### 4. Validate each unresolved thread — three passes minimum (different angle each)
+### 4. Validate each unresolved thread: three passes minimum (different angle each)
 
 Filter to only unresolved threads (`isResolved: false`). For each one, apply the canonical rigor in CLAUDE.md `Validation Rigor (Issue Identification)`:
 
@@ -56,7 +56,7 @@ Filter to only unresolved threads (`isResolved: false`). For each one, apply the
 - **Pass 2: orthogonal angle.** A different lens: callers and what they assume, related code paths, project conventions and sibling implementations, existing test coverage that may already prove the case safe.
 - **Pass 3: outside-in angle.** Sources outside the diff: `git log` / `git blame` for the why-it-is-the-way-it-is, repo-wide search for similar patterns, and for text/research-based claims (API correctness, spec compliance, deprecated patterns, security claims, library behavior) consult official docs, library source/tests, deepwiki MCP, GitHub issues, RFCs, web search. Note what was checked.
 
-Classify each as **valid**, **false positive**, **preference**, or **low-confidence** (passes did not converge — never guess). When the concern is a matter of preference, surface the trade-off rather than asserting correctness.
+Classify each as **valid**, **false positive**, **preference**, or **low-confidence** (passes did not converge; never guess). When the concern is a matter of preference, surface the trade-off rather than asserting correctness.
 
 ### 5. Present the validated list
 

--- a/roles/osx/files/claude/commands/peer-review.md
+++ b/roles/osx/files/claude/commands/peer-review.md
@@ -51,10 +51,10 @@ gh api graphql -f query='
 
 Filter to threads where `isResolved: false` AND the first comment author is NOT a `Bot` (`__typename != "Bot"`). Bot threads (Copilot and friends) belong to `/copilot-review` or `/copilot-pairing`; processing them here would generate human-tone replies to a bot.
 
-Concretely, pipe the reviewThreads response into jq:
+Pipe the previous query's output through this jq filter:
 
 ```bash
-| jq '.data.repository.pullRequest.reviewThreads.nodes
+jq '.data.repository.pullRequest.reviewThreads.nodes
     | map(select(.isResolved == false and .comments.nodes[0].author.__typename != "Bot"))'
 ```
 

--- a/roles/osx/files/claude/commands/peer-review.md
+++ b/roles/osx/files/claude/commands/peer-review.md
@@ -47,20 +47,22 @@ gh api graphql -f query='
 ' -f owner='OWNER' -f repo='REPO' -F number=NUMBER
 ```
 
-### 4. Validate each unresolved thread
+### 4. Validate each unresolved thread — three passes minimum (different angle each)
 
-Filter to only unresolved threads (`isResolved: false`). For each one:
+Filter to only unresolved threads (`isResolved: false`). For each one, apply the canonical rigor in CLAUDE.md `Validation Rigor (Issue Identification)`:
 
-- Read the full comment thread (all comments, not just the first)
-- Read the actual source code at the referenced location
-- **Validate carefully**: Determine if the concern is legitimate, a false positive, or a matter of preference
-- Consider the reviewer's perspective and intent
+- **Read first.** The full comment thread (all comments, not just the first), the actual source at the referenced location, and the reviewer's likely intent.
+- **Pass 1: direct reproduction.** When the concern is about runtime behavior, reproduce it. Failing test, repro script, trace through the code with concrete inputs. Inability to reproduce is a strong signal it may be a preference or a false positive.
+- **Pass 2: orthogonal angle.** A different lens: callers and what they assume, related code paths, project conventions and sibling implementations, existing test coverage that may already prove the case safe.
+- **Pass 3: outside-in angle.** Sources outside the diff: `git log` / `git blame` for the why-it-is-the-way-it-is, repo-wide search for similar patterns, and for text/research-based claims (API correctness, spec compliance, deprecated patterns, security claims, library behavior) consult official docs, library source/tests, deepwiki MCP, GitHub issues, RFCs, web search. Note what was checked.
+
+Classify each as **valid**, **false positive**, **preference**, or **low-confidence** (passes did not converge — never guess). When the concern is a matter of preference, surface the trade-off rather than asserting correctness.
 
 ### 5. Present the validated list
 
 For each item, include:
 - The reviewer's concern (summarized)
-- Your assessment (valid, false positive, preference)
+- Your assessment (valid, false positive, preference, low-confidence) with a one-line note on which validation passes converged
 - A proposed response draft
 - The proposed code change (if any)
 
@@ -78,6 +80,14 @@ Follow the standard review workflow (let me choose: all at once or one by one, w
 - Sound natural and human, like me writing the response myself
 
 Present each response draft for my approval before posting. I may want to adjust wording.
+
+**Solution validation when fixes are involved.** When a thread leads to a code change, apply the canonical rigor in CLAUDE.md `Validation Rigor (Solutions)`:
+
+1. **Targeted test.** Write a failing test for the bug's exact reason, confirm it fails for the right reason, apply the fix, confirm it now passes.
+2. **Wider check.** Run the broader test suite, linters, type-checkers. Watch for regressions.
+3. **Edge / integration / manual** (when relevant). Boundary cases, integration / smoke tests, or manual exercise of the user-facing flow.
+
+For non-testable changes, substitute review angles per the canonical doctrine and note in the reply why no test was added.
 
 ### 7. Commit and push
 

--- a/roles/osx/files/claude/commands/peer-review.md
+++ b/roles/osx/files/claude/commands/peer-review.md
@@ -95,6 +95,8 @@ After all items are addressed, commit the changes and push.
 
 ### 8. Reply to and resolve each thread (only after I approve the response)
 
+**Use `addPullRequestReviewThreadReply` only.** Do **NOT** use `addPullRequestReviewComment` (with or without `inReplyTo`) for this workflow. `addPullRequestReviewComment` builds up a *pending* review that must be submitted via a separate `submitPullRequestReview` mutation, and replies posted that way silently sit as drafts until someone clicks Submit. The right mutation for replying to an existing review thread is `addPullRequestReviewThreadReply`, which posts the reply immediately.
+
 **Shell quoting rules:**
 - Always use multi-line query strings for GraphQL mutations. Single-line strings cause the shell to eat `$` in variable names like `$threadId`.
 - Always write the response body to a temp file and use `-F body=@file` to pass it. This avoids fish shell interpreting backticks in the body as command substitution.

--- a/roles/osx/files/claude/commands/peer-review.md
+++ b/roles/osx/files/claude/commands/peer-review.md
@@ -95,13 +95,20 @@ After all items are addressed, commit the changes and push.
 
 ### 8. Reply to and resolve each thread (only after I approve the response)
 
-**Use `addPullRequestReviewThreadReply` only.** Do **NOT** use `addPullRequestReviewComment` (with or without `inReplyTo`) for this workflow. `addPullRequestReviewComment` builds up a *pending* review that must be submitted via a separate `submitPullRequestReview` mutation, and replies posted that way silently sit as drafts until someone clicks Submit. The right mutation for replying to an existing review thread is `addPullRequestReviewThreadReply`, which posts the reply immediately.
+**Use `addPullRequestReviewThreadReply` only.** Do **NOT** use `addPullRequestReviewComment` (with or without `inReplyTo`) for this workflow.
+
+Both mutations can leave replies invisible by attaching them to a *pending* review owned by the viewer:
+
+- `addPullRequestReviewComment` always builds onto a review and creates a pending one if none is in progress; replies sit as drafts until someone manually clicks Submit.
+- `addPullRequestReviewThreadReply` is the more direct mutation, but per a 2026-05-02 live-run failure on `SymmetrySoftware/stl-poc#13` it can also auto-vivify a pending review when the viewer has none in progress. The reply then stays invisible (to GitHub UI, to the human reviewer, to anyone else) until the pending review is submitted.
+
+After the batch of replies, **always** submit any pending review you own on this PR before resolving threads (see "Submit any auto-vivified pending review" below). A successful-looking run can otherwise complete with all replies silently invisible: the human reviewer sees no response and the threads still appear unanswered to them.
 
 **Shell quoting rules:**
 - Always use multi-line query strings for GraphQL mutations. Single-line strings cause the shell to eat `$` in variable names like `$threadId`.
 - Always write the response body to a temp file and use `-F body=@file` to pass it. This avoids fish shell interpreting backticks in the body as command substitution.
 
-For each thread, run both mutations in sequence:
+For each thread, run the reply mutation. After the whole batch of replies, run the pending-review submit step **once**, then run the resolve mutation per thread.
 
 **Reply to the thread** (use the thread `id` from step 3, not the comment id):
 
@@ -118,6 +125,42 @@ gh api graphql -f query='
   }
 ' -f threadId='THREAD_ID' -F body=@/tmp/gh-review-comment.txt
 ```
+
+**Submit any auto-vivified pending review** (run once after all replies are posted, before resolving):
+
+Query the PR's pending reviews and the viewer's login in one round-trip, then submit each pending review owned by the viewer:
+
+```bash
+gh api graphql -f query='
+  query($owner: String!, $repo: String!, $number: Int!) {
+    viewer { login }
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $number) {
+        reviews(states: PENDING, first: 10) {
+          nodes { id author { login } }
+        }
+      }
+    }
+  }
+' -f owner='OWNER' -f repo='REPO' -F number=NUMBER
+```
+
+For each `reviews.nodes` entry where `author.login == viewer.login`:
+
+```bash
+gh api graphql -f query='
+  mutation($id: ID!) {
+    submitPullRequestReview(input: {
+      pullRequestReviewId: $id,
+      event: COMMENT
+    }) {
+      pullRequestReview { id state submittedAt }
+    }
+  }
+' -f id='REVIEW_ID'
+```
+
+Re-run the pending-reviews query and assert no pending reviews owned by the viewer remain. If a pending review cannot be submitted, stop and surface the error rather than silently resolving threads on top of invisible replies.
 
 **Resolve the thread:**
 

--- a/roles/osx/files/claude/commands/peer-review.md
+++ b/roles/osx/files/claude/commands/peer-review.md
@@ -49,7 +49,16 @@ gh api graphql -f query='
 
 ### 4. Validate each unresolved thread: three passes minimum (different angle each)
 
-Filter to threads where `isResolved: false` AND the first comment author is NOT a `Bot` (`__typename != "Bot"`). Bot threads (Copilot and friends) belong to `/copilot-review` or `/copilot-pairing`; processing them here would generate human-tone replies to a bot. For each remaining thread, apply the canonical rigor in CLAUDE.md `Validation Rigor (Issue Identification)`:
+Filter to threads where `isResolved: false` AND the first comment author is NOT a `Bot` (`__typename != "Bot"`). Bot threads (Copilot and friends) belong to `/copilot-review` or `/copilot-pairing`; processing them here would generate human-tone replies to a bot.
+
+Concretely, pipe the reviewThreads response into jq:
+
+```bash
+| jq '.data.repository.pullRequest.reviewThreads.nodes
+    | map(select(.isResolved == false and .comments.nodes[0].author.__typename != "Bot"))'
+```
+
+For each remaining thread, apply the canonical rigor in CLAUDE.md `Validation Rigor (Issue Identification)`:
 
 - **Read first.** The full comment thread (all comments, not just the first), the actual source at the referenced location, and the reviewer's likely intent.
 - **Pass 1: direct reproduction.** When the concern is about runtime behavior, reproduce it. Failing test, repro script, trace through the code with concrete inputs. Inability to reproduce is a strong signal it may be a preference or a false positive.

--- a/roles/osx/files/claude/commands/peer-review.md
+++ b/roles/osx/files/claude/commands/peer-review.md
@@ -51,6 +51,8 @@ gh api graphql -f query='
 
 Filter to threads where `isResolved: false` AND the first comment author is NOT a `Bot` (`__typename != "Bot"`). Bot threads (Copilot and friends) belong to `/copilot-review` or `/copilot-pairing`; processing them here would generate human-tone replies to a bot.
 
+**Known gap.** This filter excludes *all* bots, but `/copilot-review` and `/copilot-pairing` only handle the Copilot bot specifically (filtered by `author.login`). Non-Copilot bot threads (e.g., CodeQL, Dependabot review) are therefore not handled by any of these workflows. Address them out-of-band: reply/resolve manually, or copy this command and narrow the filter to a specific bot login plus adjust the tone instructions for that bot. The current trade-off is deliberate: human tone is wrong for a bot, and Copilot tone is wrong for non-Copilot bots, so silent exclusion beats applying the wrong workflow.
+
 Pipe the previous query's output through this jq filter:
 
 ```bash

--- a/roles/osx/files/claude/commands/self-review.md
+++ b/roles/osx/files/claude/commands/self-review.md
@@ -19,11 +19,21 @@ Do a comprehensive code review of the current feature branch.
    - Dead code or unnecessary changes
    - If a Jira ticket was found: whether the changes satisfy each acceptance criterion, and whether anything is missing or inconsistent with the ticket requirements
 
-4. **Validate every finding**: For each potential issue, read the full source file to understand context. Eliminate false positives and speculative concerns. Only report issues you are confident about.
+4. **Validate every finding with the three-pass rigor** (canonical spec in CLAUDE.md `Validation Rigor (Issue Identification)`). For each potential issue:
+   - **Pass 1 (reproduce):** when the claim is about runtime behavior, reproduce it. Failing test, repro script, trace through the code path with concrete inputs, or construct the failing input.
+   - **Pass 2 (orthogonal angle):** look at callers / upstream context, related code paths, project conventions, sibling implementations, existing tests that may already cover the case.
+   - **Pass 3 (outside-in):** consult `git log` / `git blame` for context, repo-wide search for similar patterns, and for text/research-based claims (API correctness, spec compliance, deprecated patterns, security claims, library behavior) consult official docs, library source/tests, deepwiki MCP, GitHub issues, RFCs, web search. Note what was checked.
 
-5. Present the validated list as a numbered summary with brief descriptions. Clearly state the confidence level. If nothing substantive remains, say so.
+   Drop or downgrade items where the three passes do not converge. Eliminate false positives and speculative concerns. Only report issues you are confident about.
 
-6. Follow the standard review workflow (let me choose: all at once or one by one, with progress tracking).
+5. Present the validated list as a numbered summary with brief descriptions. For each item, include the confidence level and a one-line note on which validation passes converged. If nothing substantive remains, say so.
+
+6. Follow the standard review workflow (let me choose: all at once or one by one, with progress tracking). When implementing fixes, apply the **two-or-three-angle solution validation** (canonical spec in CLAUDE.md `Validation Rigor (Solutions)`):
+   - Targeted failing test for the bug's exact reason → fix → confirm test passes.
+   - Run the broader test suite, linters, and type-checkers. Watch for regressions.
+   - When relevant: edge cases (null, empty, max, concurrency), integration / smoke tests, or manual exercise of the user-facing flow.
+
+   For non-testable changes, substitute review angles (re-read the diff, read from each caller's perspective, grep for places the change could silently break) and note why no test was added.
 
 7. **Documentation check**: Before committing, verify that all documentation affected by the changes is up to date. For each changed file, consider whether any of the following need updates:
    - **Docstrings and inline docs**: Functions, classes, or modules whose behavior or signature changed


### PR DESCRIPTION
## Summary

- **New `/copilot-pairing` slash command** (`roles/osx/files/claude/commands/copilot-pairing.md`): autonomous loop of the Copilot review process. Per iteration: validate threads, implement fixes test-first when applicable, run the project's check suite, push, re-request Copilot review, poll up to 10 minutes for the response, repeat. Caps at 10 iterations. Hard stop conditions baked in for ambiguity, scope creep, test failure, security-sensitive changes, loop detection, low-confidence findings, no response, and conflicting signals.
- **Canonical `Validation Rigor` doctrine in `CLAUDE.md`**: two new subsections under `Code & PR Reviews`.
  - *Issue identification*: 3 passes minimum, different angles each. Pass 1 = direct reproduction (failing test, repro script, trace). Pass 2 = orthogonal angle (callers, conventions, sibling implementations, existing coverage). Pass 3 = outside-in (`git log`/`blame`, repo-wide search, and for text/research-based claims: official docs, library source/tests, deepwiki MCP, GitHub issues, RFCs, web search). Drop or downgrade items where passes do not converge.
  - *Solutions*: 2 angles minimum, 3 when relevant. Targeted failing test, wider check (suite + lint + types), then edge cases / integration / manual. Substitute review angles for non-testable changes.
- **All five review skills updated** to reference and apply the doctrine: `self-review`, `copilot-review`, `copilot-pairing`, `peer-review`, `code-review`.
- **`copilot-review` overhaul**: collapsed the old first-pass/second-pass into the canonical 3-pass step, presents findings as a Markdown table (`# | Thread ID | File:Line | Copilot's concern | What we found | Reproduced? | Classification | Confidence | Our proposed fix`), enforces "do not trust Copilot's recommendation, design our own fix" and applies the same rigor to the proposed fix. Replies cite which passes were checked.
- **Workflows section in `CLAUDE.md`** now lists four workflows (was three) including `/copilot-pairing`.

## Implementation notes

- Copilot bot identity confirmed live on `SymmetrySoftware/stl-poc#13`: GraphQL `author { __typename: "Bot", login: "copilot-pull-request-reviewer" }`. Reviews come in as `state: COMMENTED` (not `CHANGES_REQUESTED`). Pairing's done-detection is "Copilot review submitted after our push that creates zero new unresolved threads".
- Pairing's re-request path is mode-aware (set in pre-flight from `__typename`):
  - `app` mode (bot is `__typename: Bot`, e.g. Copilot installed as a GitHub App): the REST endpoint `POST /repos/{owner}/{repo}/pulls/{number}/requested_reviewers` returns 422 "not a collaborator" for App-typed reviewers, so we call the GitHub MCP `request_copilot_review` tool instead (it wraps an internal endpoint that accepts Bot reviewers) and verify by re-querying `reviewRequests.nodes` for the bot login.
  - `collaborator` mode: REST `POST /requested_reviewers` with `reviewers[]=copilot-pull-request-reviewer`, with a DELETE-then-POST retry for the 422 "already requested" case.
  - Either way, step (g)'s 10-minute GraphQL poll for a new Copilot review (filtered by author login plus a baseline-id/timestamp combined predicate) is the authoritative confirmation. Auto-review-on-push has been observed to silently no-op in app mode, so the explicit re-request and the poll are both load-bearing.
- No Ansible task changes needed: `roles/osx/files/claude/commands/` is symlinked wholesale, so the new file is picked up on the next session. Memory file (`MEMORY.md`) updated locally to record the bot login.

## Test plan

- [ ] `readlink ~/.claude/commands/copilot-pairing.md` resolves into `roles/osx/files/claude/commands/copilot-pairing.md`
- [ ] Fresh Claude Code session lists `/copilot-pairing` in available skills
- [ ] `/copilot-review` on a PR with open Copilot threads narrates the 3 passes and produces the table
- [ ] `/copilot-pairing` on a small PR drives at least one full iteration (validate, test-first fix, push, re-request, poll, resume) and a stop condition (ambiguity or iteration cap on contrived input) hands control back cleanly
- [ ] `/self-review`, `/peer-review`, `/code-review` each cite which validation passes converged for at least one finding when run on a real diff
- [ ] CLAUDE.md `Validation Rigor` headings render in the materialized `~/.claude/CLAUDE.md` after the next Ansible run
