### PR TITLE
fix(claude): tighten /self-review doc lens and propagate pre-push hook handling to siblings

### DIFF
--- a/roles/osx/files/claude/commands/copilot-pairing.md
+++ b/roles/osx/files/claude/commands/copilot-pairing.md
@@ -84,7 +84,7 @@ Order matters: land the code first, then talk about it. If we replied/resolved b
 1. **Commit and push.**
    - `git add` only the files we actually changed for this iteration (never `git add -A`).
    - Commit with a message of the form `chore(copilot): iter N, address <short summary>`.
-   - Push: `git push origin <branch>`. **Never** `--force`, `--force-with-lease`, or any rebase flag.
+   - Push: `git push origin <branch>`. **Never** `--force`, `--force-with-lease`, or any rebase flag. If the push fails on a hook (pre-push test, security check, lefthook stage, etc.), trigger the **Push hook failure** stop condition; do not silently retry, do not bypass with `--no-verify`, and do not "fix" unrelated test flakes inside this branch.
 2. **Capture poll-window start epoch and baseline Copilot-review id** (substitute the PR number from pre-flight step 1; substitute the verified bot login from pre-flight step 3 in the `--arg bot ...` flag if it differs from the default, otherwise the baseline file silently lands empty and step (g) loses its disambiguation):
    ```bash
    echo $(( $(date +%s) - 2 )) > /tmp/copilot-pairing-push-epoch.NUMBER
@@ -328,6 +328,7 @@ If any condition fires, **stop**. Print the latest iteration table, name the con
 | **Persistent resolve failure** | A `resolveReviewThread` mutation has silently failed (or been rolled back) for the same threads across two consecutive iterations, so the resolve-only short-circuit in step f.5 cannot drain the queue. |
 | **Scope creep** | A fix would touch code outside the PR's existing diff, or contradicts the PR's stated intent / Jira AC. When SOME threads are in-scope and others are not, see "Partial scope creep" below for the recipe before stopping. |
 | **Test failure** | Any test, linter, type-check, or formatter fails after our change, including pre-existing failures we surface for the first time. |
+| **Push hook failure** | `git push origin <branch>` (step (e.1)) fails on a hook (pre-push test, security check, lefthook stage, etc.). Diagnose whether the failure traces to this iteration's diff or to pre-existing / unrelated state, surface the diagnosis, and hand off. Do not silently retry, do not bypass with `--no-verify`, and do not "fix" unrelated test flakes inside this branch. |
 | **Security-sensitive** | The change touches auth, secrets handling, crypto, permissions, IAM, SQL/shell construction, or sandbox boundaries. Always pause. |
 | **High false-positive ratio** | At least 3 threads in the iteration AND more than half are false positives (model may be misreading the change). Pause for re-alignment. |
 | **Iteration cap** | 10 iterations completed without convergence. Stop and report. |
@@ -355,6 +356,7 @@ When an iteration's threads split between in-scope (lines this PR introduced or 
 
 These hold at every step:
 - **Never** `git push --force` or `--force-with-lease`.
+- **Never** silently retry a failed `git push` or bypass with `--no-verify`. Trigger the **Push hook failure** stop condition with a brief diagnosis instead.
 - **Never** amend, squash, or rebase commits already pushed.
 - **Never** resolve a thread without an explanatory reply.
 - **Never** skip the failing-test-first step on a behavior-changing fix.

--- a/roles/osx/files/claude/commands/copilot-review.md
+++ b/roles/osx/files/claude/commands/copilot-review.md
@@ -139,6 +139,8 @@ For **low-confidence**: pause and ask me before taking action.
 
 After all items are addressed, commit the changes and push.
 
+**If the push fails on a hook (pre-push test, security check, lefthook stage, etc.):** diagnose whether the failure is caused by this branch's diff or by something pre-existing / unrelated (a flaky test, a broken main, a security check tripping on untouched code). If unrelated to the diff, surface the failure to me with a brief diagnosis and ask whether to (a) investigate and fix in-scope, (b) bypass with `--no-verify` (only with explicit per-push permission from me; never assume), or (c) hold off pushing. Do not silently retry, do not bypass without explicit consent, and do not "fix" unrelated test flakes inside this branch without checking first.
+
 ### 8. Reply to and resolve each thread
 
 **Use `addPullRequestReviewThreadReply` only.** Do **NOT** use `addPullRequestReviewComment` (with or without `inReplyTo`) for this workflow.

--- a/roles/osx/files/claude/commands/copilot-review.md
+++ b/roles/osx/files/claude/commands/copilot-review.md
@@ -139,7 +139,7 @@ For **low-confidence**: pause and ask me before taking action.
 
 After all items are addressed, commit the changes and push.
 
-**If the push fails on a hook (pre-push test, security check, lefthook stage, etc.):** diagnose whether the failure is caused by this branch's diff or by something pre-existing / unrelated (a flaky test, a broken main, a security check tripping on untouched code). If unrelated to the diff, surface the failure to me with a brief diagnosis and ask whether to (a) investigate and fix in-scope, (b) bypass with `--no-verify` (only with explicit per-push permission from me; never assume), or (c) hold off pushing. Do not silently retry, do not bypass without explicit consent, and do not "fix" unrelated test flakes inside this branch without checking first.
+**If the push fails on a hook (pre-push test, security check, lefthook stage, etc.):** diagnose whether the failure is caused by this branch's diff or by something pre-existing / unrelated (a flaky test, a broken main, a security check tripping on untouched code). Surface the diagnosis to me and ask whether to (a) investigate and fix in-scope, or (b) hold off pushing. Do not silently retry, **never** bypass with `--no-verify` (the repo policy in `.github/copilot-instructions.md` and the global CLAUDE.md "Executing actions with care" rule both forbid it), and do not "fix" unrelated test flakes inside this branch without checking first.
 
 ### 8. Reply to and resolve each thread
 

--- a/roles/osx/files/claude/commands/copilot-review.md
+++ b/roles/osx/files/claude/commands/copilot-review.md
@@ -139,7 +139,7 @@ For **low-confidence**: pause and ask me before taking action.
 
 After all items are addressed, commit the changes and push.
 
-**If the push fails on a hook (pre-push test, security check, lefthook stage, etc.):** diagnose whether the failure is caused by this branch's diff or by something pre-existing / unrelated (a flaky test, a broken main, a security check tripping on untouched code). Surface the diagnosis to me and ask whether to (a) investigate and fix in-scope, or (b) hold off pushing. Do not silently retry, **never** bypass with `--no-verify` (the repo policy in `.github/copilot-instructions.md` and the global CLAUDE.md "Executing actions with care" rule both forbid it), and do not "fix" unrelated test flakes inside this branch without checking first.
+**If the push fails on a hook (pre-push test, security check, lefthook stage, etc.):** diagnose whether the failure is caused by this branch's diff or by something pre-existing / unrelated (a flaky test, a broken main, a security check tripping on untouched code). Surface the diagnosis to me and ask whether to (a) investigate and fix in-scope, or (b) hold off pushing. Do not silently retry, **never** bypass with `--no-verify` (the repo policy in `.github/copilot-instructions.md:122-123` forbids it), and do not "fix" unrelated test flakes inside this branch without checking first.
 
 ### 8. Reply to and resolve each thread
 

--- a/roles/osx/files/claude/commands/peer-review.md
+++ b/roles/osx/files/claude/commands/peer-review.md
@@ -124,6 +124,8 @@ For non-testable changes, substitute review angles per the canonical doctrine an
 
 After all items are addressed, commit the changes and push.
 
+**If the push fails on a hook (pre-push test, security check, lefthook stage, etc.):** diagnose whether the failure is caused by this branch's diff or by something pre-existing / unrelated (a flaky test, a broken main, a security check tripping on untouched code). If unrelated to the diff, surface the failure to me with a brief diagnosis and ask whether to (a) investigate and fix in-scope, (b) bypass with `--no-verify` (only with explicit per-push permission from me; never assume), or (c) hold off pushing. Do not silently retry, do not bypass without explicit consent, and do not "fix" unrelated test flakes inside this branch without checking first.
+
 ### 8. Reply to and resolve each thread (only after I approve the response)
 
 **Use `addPullRequestReviewThreadReply` only.** Do **NOT** use `addPullRequestReviewComment` (with or without `inReplyTo`) for this workflow.

--- a/roles/osx/files/claude/commands/peer-review.md
+++ b/roles/osx/files/claude/commands/peer-review.md
@@ -124,7 +124,7 @@ For non-testable changes, substitute review angles per the canonical doctrine an
 
 After all items are addressed, commit the changes and push.
 
-**If the push fails on a hook (pre-push test, security check, lefthook stage, etc.):** diagnose whether the failure is caused by this branch's diff or by something pre-existing / unrelated (a flaky test, a broken main, a security check tripping on untouched code). If unrelated to the diff, surface the failure to me with a brief diagnosis and ask whether to (a) investigate and fix in-scope, (b) bypass with `--no-verify` (only with explicit per-push permission from me; never assume), or (c) hold off pushing. Do not silently retry, do not bypass without explicit consent, and do not "fix" unrelated test flakes inside this branch without checking first.
+**If the push fails on a hook (pre-push test, security check, lefthook stage, etc.):** diagnose whether the failure is caused by this branch's diff or by something pre-existing / unrelated (a flaky test, a broken main, a security check tripping on untouched code). Surface the diagnosis to me and ask whether to (a) investigate and fix in-scope, or (b) hold off pushing. Do not silently retry, **never** bypass with `--no-verify` (the repo policy in `.github/copilot-instructions.md` and the global CLAUDE.md "Executing actions with care" rule both forbid it), and do not "fix" unrelated test flakes inside this branch without checking first.
 
 ### 8. Reply to and resolve each thread (only after I approve the response)
 

--- a/roles/osx/files/claude/commands/peer-review.md
+++ b/roles/osx/files/claude/commands/peer-review.md
@@ -124,7 +124,7 @@ For non-testable changes, substitute review angles per the canonical doctrine an
 
 After all items are addressed, commit the changes and push.
 
-**If the push fails on a hook (pre-push test, security check, lefthook stage, etc.):** diagnose whether the failure is caused by this branch's diff or by something pre-existing / unrelated (a flaky test, a broken main, a security check tripping on untouched code). Surface the diagnosis to me and ask whether to (a) investigate and fix in-scope, or (b) hold off pushing. Do not silently retry, **never** bypass with `--no-verify` (the repo policy in `.github/copilot-instructions.md` and the global CLAUDE.md "Executing actions with care" rule both forbid it), and do not "fix" unrelated test flakes inside this branch without checking first.
+**If the push fails on a hook (pre-push test, security check, lefthook stage, etc.):** diagnose whether the failure is caused by this branch's diff or by something pre-existing / unrelated (a flaky test, a broken main, a security check tripping on untouched code). Surface the diagnosis to me and ask whether to (a) investigate and fix in-scope, or (b) hold off pushing. Do not silently retry, **never** bypass with `--no-verify` (the repo policy in `.github/copilot-instructions.md:122-123` forbids it), and do not "fix" unrelated test flakes inside this branch without checking first.
 
 ### 8. Reply to and resolve each thread (only after I approve the response)
 

--- a/roles/osx/files/claude/commands/self-review.md
+++ b/roles/osx/files/claude/commands/self-review.md
@@ -57,7 +57,7 @@ Do a comprehensive code review of the current feature branch.
 
 9. If the review found nothing substantive (or after addressing everything), offer to push the branch. Then handle the PR, gracefully reusing an existing one if present:
 
-   **If the push fails on a hook (pre-push test, security check, lefthook stage, etc.):** diagnose whether the failure is caused by this branch's diff or by something pre-existing / unrelated (a flaky test, a broken main, a security check tripping on untouched code). Surface the diagnosis to me and ask whether to (a) investigate and fix in-scope, or (b) hold off pushing. Do not silently retry, **never** bypass with `--no-verify` (the repo policy in `.github/copilot-instructions.md` and the global CLAUDE.md "Executing actions with care" rule both forbid it), and do not "fix" unrelated test flakes inside this branch without checking first.
+   **If the push fails on a hook (pre-push test, security check, lefthook stage, etc.):** diagnose whether the failure is caused by this branch's diff or by something pre-existing / unrelated (a flaky test, a broken main, a security check tripping on untouched code). Surface the diagnosis to me and ask whether to (a) investigate and fix in-scope, or (b) hold off pushing. Do not silently retry, **never** bypass with `--no-verify` (the repo policy in `.github/copilot-instructions.md:122-123` forbids it), and do not "fix" unrelated test flakes inside this branch without checking first.
 
    **Check if a PR already exists for this branch:**
    ```

--- a/roles/osx/files/claude/commands/self-review.md
+++ b/roles/osx/files/claude/commands/self-review.md
@@ -57,7 +57,7 @@ Do a comprehensive code review of the current feature branch.
 
 9. If the review found nothing substantive (or after addressing everything), offer to push the branch. Then handle the PR, gracefully reusing an existing one if present:
 
-   **If the push fails on a hook (pre-push test, security check, lefthook stage, etc.):** diagnose whether the failure is caused by this branch's diff or by something pre-existing / unrelated (a flaky test, a broken main, a security check tripping on untouched code). If unrelated to the diff, surface the failure to me with a brief diagnosis and ask whether to (a) investigate and fix in-scope, (b) bypass with `--no-verify` (only with explicit per-push permission from me; never assume), or (c) hold off pushing. Do not silently retry, do not bypass without explicit consent, and do not "fix" unrelated test flakes inside this branch without checking first.
+   **If the push fails on a hook (pre-push test, security check, lefthook stage, etc.):** diagnose whether the failure is caused by this branch's diff or by something pre-existing / unrelated (a flaky test, a broken main, a security check tripping on untouched code). Surface the diagnosis to me and ask whether to (a) investigate and fix in-scope, or (b) hold off pushing. Do not silently retry, **never** bypass with `--no-verify` (the repo policy in `.github/copilot-instructions.md` and the global CLAUDE.md "Executing actions with care" rule both forbid it), and do not "fix" unrelated test flakes inside this branch without checking first.
 
    **Check if a PR already exists for this branch:**
    ```

--- a/roles/osx/files/claude/commands/self-review.md
+++ b/roles/osx/files/claude/commands/self-review.md
@@ -19,6 +19,7 @@ Do a comprehensive code review of the current feature branch.
       - The tooling output from (a)
       - A narrow brief: "find issues in this diff for ONE lens only: `<lens>`. Be exhaustive within your lens. Severity-pruning is forbidden. If no findings, return `none` with a one-line reason. Cite linter / type-checker rules when they fire."
       - The lens's specific concerns, copied verbatim from CLAUDE.md `Discovery Rigor (Issue Identification)` so the sub-agent does not have to re-read it.
+      - **Documentation and Cross-file consistency lenses, extra instruction:** when a spec, README, RFC, ADR, or other doc contains a code snippet, config block, or quoted contract that mirrors an implementation file, diff the snippet **line-by-line** against the file it mirrors. Do not stop at "do they roughly agree?" or pattern-match on the most-visible change (e.g., a renamed identifier) and miss multi-line drift (TTLs, output names, source fields, missing preconditions, signature changes). Report every divergence; the snippet is a contract, not a sketch.
 
    c. **Coordinator merges and dedupes.** A finding hitting two lenses gets one row with both lens labels. Apply the **review-mode refactor instinct** filter (CLAUDE.md `Refactor Instinct`): drop refactor flags that are not anchored in tool output and do not represent this-PR-makes-it-worse. Pre-existing mess unrelated to the diff is out of scope.
 
@@ -55,6 +56,8 @@ Do a comprehensive code review of the current feature branch.
 8. After all items are addressed, commit the changes.
 
 9. If the review found nothing substantive (or after addressing everything), offer to push the branch. Then handle the PR, gracefully reusing an existing one if present:
+
+   **If the push fails on a hook (pre-push test, security check, lefthook stage, etc.):** diagnose whether the failure is caused by this branch's diff or by something pre-existing / unrelated (a flaky test, a broken main, a security check tripping on untouched code). If unrelated to the diff, surface the failure to me with a brief diagnosis and ask whether to (a) investigate and fix in-scope, (b) bypass with `--no-verify` (only with explicit per-push permission from me; never assume), or (c) hold off pushing. Do not silently retry, do not bypass without explicit consent, and do not "fix" unrelated test flakes inside this branch without checking first.
 
    **Check if a PR already exists for this branch:**
    ```


### PR DESCRIPTION
## Summary

- **`/self-review` doc-lens tightening** (`self-review.md` step 3.b): added an extra instruction for the Documentation and Cross-file consistency lens sub-agents. When a doc contains a code snippet, config block, or quoted contract that mirrors an implementation file, the sub-agent must diff the snippet line-by-line against the file it mirrors. The motivating failure mode: pattern-matching on the most visible change (e.g., a renamed identifier) and missing multi-line drift in TTLs, output names, source fields, missing preconditions, or signature changes. The snippet is a contract, not a sketch.
- **Pre-push hook failure handling rule** added to `/self-review` step 9: if `git push` fails on a hook (pre-push test, security check, lefthook stage, etc.), diagnose whether the failure traces to this branch's diff or to pre-existing / unrelated state, surface the diagnosis, and ask whether to (a) investigate and fix in-scope, or (b) hold off pushing. **Never** bypass with `--no-verify` (the repo policy in `.github/copilot-instructions.md:122-123` forbids it), do not silently retry, do not "fix" unrelated test flakes inside this branch.
- **Cross-file consistency follow-up** (surfaced by `/polish` on this branch): propagated the pre-push rule to the three sibling commands that also push.
  - `/copilot-review` step 7 and `/peer-review` step 7: verbatim wording from `/self-review` (single-shot interactive push, user available for the (a)/(b) prompt).
  - `/copilot-pairing` step 87: adapted for the autonomous loop. Step 87 trips a new **Push hook failure** stop condition; a matching auto-execution invariant ("never silently retry a failed push or bypass with `--no-verify`") sits alongside the existing "never `--force`" line. Stop condition handoff uses the existing "wait for me" machinery so the human gets the diagnosis without a real-time prompt.
- **Policy alignment fix** (surfaced by Copilot on this PR, iter 1): the initial wording offered `--no-verify` as a gated option, which conflicts with `.github/copilot-instructions.md:122-123`. Reduced to two options (investigate/fix vs hold off) and reframed the trailing clause as "**never** bypass with `--no-verify`". Applied across `/self-review`, `/copilot-review`, `/peer-review`; `/copilot-pairing` already used the never-framing throughout.
- **Citation correction** (surfaced by Copilot on this PR, iter 3): iter 1's wording also cited a "global CLAUDE.md 'Executing actions with care' rule" that does not exist in any tracked CLAUDE.md (hallucinated from Claude Code's base system prompt, which is not a citable user-tracked doc). Dropped that clause; kept only the verifiable `.github/copilot-instructions.md:122-123` citation.

## Test plan

- [ ] After the next Ansible run, `readlink ~/.claude/commands/{self-review,copilot-review,peer-review,copilot-pairing}.md` resolves into the tracked sources and the new wording is present in each.
- [ ] `/self-review` on a doc-heavy branch whose changes include a snippet mirroring an implementation file: the Documentation / Cross-file consistency sub-agent reports line-by-line drift, not just the most visible difference.
- [ ] `/self-review` push attempt against a branch where a pre-push hook fires on unrelated state: the skill diagnoses, presents the (a)/(b) prompt, and never bypasses with `--no-verify`.
- [ ] `/copilot-review` and `/peer-review` push attempts against the same scenario: same (a)/(b) prompt as `/self-review`.
- [ ] `/copilot-pairing` iteration where the push trips a hook: the loop triggers the **Push hook failure** stop condition, prints the latest iteration table, surfaces the diagnosis, and waits for the human. No silent retry, no `--no-verify`.
- [ ] grep across `roles/osx/files/claude/commands/` shows no remaining `(b) bypass with --no-verify` option-framing, no "global CLAUDE.md Executing actions with care" citation, and the new "never `--no-verify`" framing with `.github/copilot-instructions.md:122-123` citation is present in `self-review.md`, `copilot-review.md`, `peer-review.md`. `copilot-pairing.md` carries the same rule via stop-condition + invariant.