### PR TITLE
fix(claude): tighten /polish inline-walk floor and document dialyzer skip false-positive

### DIFF
--- a/roles/osx/files/claude/commands/polish.md
+++ b/roles/osx/files/claude/commands/polish.md
@@ -37,7 +37,7 @@ Inline walking does not waive any other invariant: the lens-coverage table, the 
 
 **Known false-positive patterns.** Some tool outputs look like cleanup candidates but are intentional. Drop these at discovery rather than routing them anywhere:
 
-- **Dialyzer `:unnecessary_skip` against paths outside the current env's `elixirc_paths`** (commonly `test/support/*` files surfaced when running `mix dialyzer` directly instead of `mix ci`). The skip filter is intentional CI-side coverage for code dialyzer cannot see from the dev compile path; removing it would silently lose CI coverage. If you cannot determine whether the skip target is reachable from the current env's compile path, route to Needs human attention rather than Auto-applicable.
+- **Dialyzer `:unnecessary_skip` against paths outside the current env's `elixirc_paths`** (commonly `test/support/*` files surfaced when running `mix dialyzer` directly instead of `mix ci`). The skip filter is intentional CI-side coverage for code Dialyzer cannot see from the dev compile path; removing it would silently lose CI coverage. If you cannot determine whether the skip target is reachable from the current env's compile path, route to Needs human attention rather than Auto-applicable.
 
 ### b. Categorize per CLAUDE.md `Finding Categorization`
 

--- a/roles/osx/files/claude/commands/polish.md
+++ b/roles/osx/files/claude/commands/polish.md
@@ -31,9 +31,13 @@ Apply `/self-review` step 3 (lens walk + tooling sweep + self-critique), then va
 
 - **Doc/config dominant.** More than 80% of changed lines are in markdown, YAML, JSON, or TOML.
 - **Narrow code surface.** At most 2 files contain executable code (shell, Ruby, Python, Go, etc.).
-- **Modest total size.** Fewer than ~500 changed lines.
+- **Modest total size.** Fewer than ~300 changed lines.
 
-Inline walking does not waive any other invariant: the lens-coverage table, the no-silent-pruning rule, and the mandatory self-critique pass all still apply. CLAUDE.md `Discovery Rigor` prefers fan-out for non-trivial diffs and explicitly grants skills the authority to specify when to walk inline; this section exercises that authority.
+Inline walking does not waive any other invariant: the lens-coverage table, the no-silent-pruning rule, and the mandatory self-critique pass all still apply. CLAUDE.md `Discovery Rigor` prefers fan-out for non-trivial diffs and explicitly grants skills the authority to specify when to walk inline; this section exercises that authority. The bar is intentionally low because a single coordinator agent self-prunes once a diff is even mid-size, and fan-out is cheap insurance.
+
+**Known false-positive patterns.** Some tool outputs look like cleanup candidates but are intentional. Drop these at discovery rather than routing them anywhere:
+
+- **Dialyzer `:unnecessary_skip` against paths outside the current env's `elixirc_paths`** (commonly `test/support/*` files surfaced when running `mix dialyzer` directly instead of `mix ci`). The skip filter is intentional CI-side coverage for code dialyzer cannot see from the dev compile path; removing it would silently lose CI coverage. If you cannot determine whether the skip target is reachable from the current env's compile path, route to Needs human attention rather than Auto-applicable.
 
 ### b. Categorize per CLAUDE.md `Finding Categorization`
 


### PR DESCRIPTION
## Summary

- **Inline-walk floor tightened** (`polish.md` step (a), Fan-out vs inline rule c): lowered the "Modest total size" threshold from `~500` to `~300` changed lines so mid-size diffs fan out by default. A single coordinator agent self-prunes once a diff is even mid-size (see CLAUDE.md `Discovery Rigor` rationale for fan-out), and the cost of spawning per-lens `Explore` sub-agents is small. Motivating case: a 21% markdown / 79% code diff at ~400 lines and ~8 executable code files qualified for inline walk under the old `~500` floor; that's well past the size where self-pruning kicks in. Added a trailing rationale clause to the existing invariants paragraph so the reasoning is co-located with the rule.
- **Dialyzer `:unnecessary_skip` false-positive note** added as a new "Known false-positive patterns" sub-section in `polish.md` step (a). When `mix dialyzer` runs directly (vs `mix ci`), it surfaces `:unnecessary_skip` on filter entries pointing at `test/support/*` and similar paths outside the dev env's `elixirc_paths`. The skip filter is intentional CI-side coverage for code dialyzer cannot see from the dev compile path; removing it would silently lose CI coverage. The sub-section frames this as one example of a pattern category ("Known false-positive patterns" plural) so the doc is extensible if other tools surface similar quirks. Includes an ambiguity fallback: if reachability is unclear, route to Needs human attention rather than Auto-applicable.
- **Scope**: doc-only change to `/polish`; no behavior change for any other command. No upstream (CLAUDE.md `Discovery Rigor`, `self-review.md` step 3) defines a competing threshold, and the FP-patterns sub-section doesn't conflict with anything else.

## Test plan

- [ ] After the next Ansible run, `readlink ~/.claude/commands/polish.md` resolves into the tracked source and the new wording is present (note: in this checkout the runtime path is currently hard-linked, not symlinked; ansible will recreate as symlink on next run).
- [ ] `/polish` on a mid-size diff (~400 changed lines, ≥3 executable code files) now fans out per-lens by default rather than walking inline.
- [ ] `/polish` on an Elixir branch where `mix dialyzer` surfaces `:unnecessary_skip` against `test/support/*` (or other path outside the current env's `elixirc_paths`) drops those findings at discovery rather than routing them to Auto-applicable for removal.
- [ ] `/polish` on a markdown-only diff (this branch is the example) still exits clean on iteration 1: no markdown linter in the project means no Auto-applicable candidates can ground, lens walk + self-critique returns no Needs human attention items, both buckets empty.