### PR TITLE
feat(claude): /panel-* commands and three-bucket Finding Categorization

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -65,6 +65,10 @@ brew "mariadb@10.6"
 brew "mysql@8.0"
 brew "postgresql@18"
 
+# AI tools (panel review / pairing backends)
+brew "ollama"
+cask "codex"
+
 # MAS CLI
 brew "mas"
 

--- a/roles/osx/files/CLAUDE.md
+++ b/roles/osx/files/CLAUDE.md
@@ -93,8 +93,8 @@ When reviewing code, features, or addressing PR feedback:
 - **Present all issues first**: After analysis, present the complete list of confirmed issues as a numbered summary with brief descriptions.
 - **Let the user choose the workflow**: Ask whether they want to review items (a) all at once / as a whole list (re-prioritize, group, bulk-dismiss), (b) one by one with discussion per item, (c) batched decisions (per-finding picklist via `AskUserQuestion`, up to 4 findings per call), or (d) clustered decisions (findings grouped by shared decision axis; one question per cluster; the answer applies to every finding in that cluster). Do not assume they want all items addressed at once. When the finding count is high (~10+), proactively suggest (c) or (d) rather than (b).
 - **Progress tracking**: In one-by-one or batched-decision mode, always show a progress tracker (e.g., `[2/7]`) so the current position and total count are always visible. In clustered-decision mode, show cluster index plus the count it covers (e.g., `cluster [2/4]: 5 findings`).
-- **Batched-decision mode**: use `AskUserQuestion` to present up to 4 findings per call, each as its own single-select question. The skill defines the option set for the workflow (e.g., `/self-review`: Address now / Defer to follow-up / Dismiss / Discuss first; `/code-review`: Post inline / Post as PR-level / Defer to follow-up / Dismiss). The auto-added "Other" handles custom decisions. Acknowledge the decisions before moving on, then act on them per the user's broader workflow choice.
-- **Clustered-decisions mode**: when many findings share a decision axis, collapse them into clusters and ask one question per cluster instead of one per finding. Strong axes: same fix template ("add missing docstrings"), same lens (docs nits, naming nits), same destination (all destined for follow-up), same scope (all in one module). One `AskUserQuestion` per cluster, single-select with cluster-wide actions derived from the skill's option set (the skill specifies its own option set, e.g. "Address all / Defer all to follow-up / Dismiss all / Pick individually" for `/self-review` and peers; "Post all inline / Post all as PR-level / Defer all to follow-up / Dismiss all / Pick individually" for `/code-review`). If "Pick individually", drop into batched-decision mode for that cluster only. Findings that fit no cluster fall back to (b) or (c). List each cluster's members briefly before the question (file:line + one-line summary) so the user can spot mis-grouped items before answering. Best when the finding list is large and several findings share an axis; weak when every finding is bespoke.
+- **Batched-decision mode**: use `AskUserQuestion` to present up to 4 findings per call, each as its own single-select question. The option set is determined by the finding's bucket per `Finding Categorization`. Needs sign-off findings use the standard `Apply / Skip / Modify` option set across every skill that surfaces them. Needs human judgment findings use **bespoke options the skill authors per finding** (the actual decision branches; generic timing options like "now / later / dismiss" are forbidden in this bucket (see `Finding Categorization` for the forcing function)). Skills that don't use the categorization (e.g., `/code-review`) define their own option set tied to the action they're taking (e.g., `/code-review`: Post inline / Post as PR-level / Defer to follow-up / Dismiss, since the workflow is drafting comments to post). The auto-added "Other" handles custom decisions. Acknowledge the decisions before moving on, then act on them per the user's broader workflow choice.
+- **Clustered-decisions mode**: when many findings share a decision axis, collapse them into clusters and ask one question per cluster instead of one per finding. Strong axes: same fix template ("apply this pattern to all"), same lens (docs nits, naming nits), same scope (all in one module), same destination. One `AskUserQuestion` per cluster, single-select with cluster-wide actions matching the cluster's bucket per `Finding Categorization`: Needs sign-off clusters get `Apply all / Skip all / Pick individually`; Needs human judgment clusters get cluster-wide options that reflect the shared axis (e.g., "Choose strict for all" / "Choose lenient for all" / "Pick individually". The same forbidden-timing rule applies, the cluster axis is what determines the options). Skills not using the categorization define their own cluster-wide options (e.g., `/code-review`: Post all inline / Post all as PR-level / Defer all to follow-up / Dismiss all / Pick individually). "Pick individually" drops into batched-decision mode for that cluster only. Findings that fit no cluster fall back to (b) or (c). List each cluster's members briefly before the question (file:line + one-line summary) so the user can spot mis-grouped items before answering. Best when the finding list is large and several findings share an axis; weak when every finding is bespoke (Needs human judgment findings often resist clustering).
 - For each item in one-by-one mode: present it, discuss it, and wait for the user's decision before moving to the next.
 - This applies to: PR review comments, code review findings, feature review feedback, and any similar review workflow.
 
@@ -162,24 +162,57 @@ Skills cite this section the same way they cite Validation Rigor. The canonical 
 
 ### Finding Categorization
 
-After Discovery Rigor produces findings and Validation Rigor confirms them, skills that **act on findings locally** (such as `/self-review`, `/polish`, and `/peer-review`, plus `/copilot-review`'s adjacent-findings output) categorize each finding into one of two buckets and present them as separate tables; `/polish` uses this split as its loop boundary. Skills that **only draft output for elsewhere** (e.g. `/code-review`, which drafts comments for the human to submit) skip the categorization and use a presentation tailored to their workflow (typically severity-grouped). They still apply Discovery Rigor and Validation Rigor in full; the categorization just doesn't gate behavior because no fixes are auto-applied.
+After Discovery Rigor produces findings and Validation Rigor confirms them, skills that **act on findings locally** (such as `/self-review`, `/polish`, `/peer-review`, `/panel-review`, `/panel-pairing`, plus `/copilot-review`'s adjacent-findings output) categorize each finding into one of three buckets and present them as separate tables. `/polish` uses the Auto-applicable bucket as its loop boundary. Skills that **only draft output for elsewhere** (e.g. `/code-review`, which drafts comments for the human to submit) skip the categorization and use a presentation tailored to their workflow (typically severity-grouped). They still apply Discovery Rigor and Validation Rigor in full; the categorization just doesn't gate behavior because no fixes are auto-applied.
 
-**Auto-applicable.** All four conditions must hold; if any is uncertain, the finding goes to Needs human attention.
+The bucket is determined by the **honest decision shape**: what the human actually needs to decide. If the only call is "apply or not", the LLM has the call; if real alternatives exist, the human does. The bucket the finding lands in must match the kind of question the human would otherwise have to answer.
+
+**Auto-applicable.** LLM applies without asking. All four conditions must hold; if any is uncertain, the finding routes to Needs sign-off (or Needs human judgment, if uncertainty is about which path to take rather than whether to apply a known fix).
 
 1. **Tool-grounded.** A specific rule was cited by a linter, formatter, type-checker, static analyzer, or dead-code detector run against the project. "I think this is a bug" does not qualify; "ruff F401: imported but unused" does. The rule citation must appear in the finding row.
 2. **Mechanical fix.** The fix is a rename, reformat, drop-unused, missing-import, missing-newline, typo, inferable-type-annotation, or similar single-step transform. No design decision, no choice between alternatives.
 3. **No user-observable behavior change.** Internal-only edits qualify. Anything that changes a public API, error message a caller could depend on, log output a downstream consumer might parse, or any external contract does not.
 4. **Validation passes converged with high confidence.** All three Validation Rigor passes agreed on the finding and the fix. Low-confidence or split-pass items are never Auto-applicable, even if they look mechanical.
 
-Additional disqualifiers regardless of the four conditions above:
+Plus the unconditional disqualifiers below. Anything disqualified routes to Needs sign-off or Needs human judgment regardless of how mechanical the fix looks; the disqualifier prevents autonomous application but does not prevent the LLM from recommending the fix.
 
-- **Security-sensitive code** (auth, secrets, crypto, permissions, IAM, SQL/shell construction, sandbox boundaries). Always Needs human attention.
-- **Migration / data / destructive ops** (schema changes, backfills, deletes, drops, anything irreversible). Always Needs human attention.
-- **CI configuration, lockfiles, `.env`, secrets files.** Always Needs human attention even if a tool flagged something.
+- **Security-sensitive code** (auth, secrets, crypto, permissions, IAM, SQL/shell construction, sandbox boundaries).
+- **Migration / data / destructive ops** (schema changes, backfills, deletes, drops, anything irreversible).
+- **CI configuration, lockfiles, `.env`, secrets files.**
 
-**Needs human attention.** Everything else. Bugs (even "obvious" ones; the user may have context the agent lacks), refactor proposals, naming changes that affect API surface, performance fixes, missing tests, design-level documentation, anything anchored in judgment over tool output.
+**Needs sign-off.** LLM has a single specific recommended fix and validation converged with high confidence, but the change warrants human approval before landing. The decision the human is making is "apply this exact fix, yes or no", not "what to do" (that's Needs human judgment) and not "when" (which routes here as "yes, apply now" by default).
 
-Skills using the categorization present these as **two tables in a fixed order**: Auto-applicable first, then Needs human attention. If either bucket is empty, the table still appears with a single row stating `none` so the empty bucket is visible (silent omission is the failure mode the canonical lens-coverage table also guards against).
+Route to this bucket when any of these hold:
+
+- The fix touches a public API, error contract, log format, or any external interface.
+- The fix causes a user-observable behavior change but the resolution is clearly correct.
+- The change is in security-sensitive code, a migration / destructive op, CI config, a lockfile, `.env`, or a secrets file (the disqualifiers above), and the LLM has an unambiguous recommended fix.
+- The fix is multi-step or non-mechanical (Auto-applicable condition 2 fails) but the path is unambiguous; the LLM has one best fix, not a choice among alternatives.
+
+**Decision shape: `Apply / Skip / Modify`** (auto-added "Other"). The standard option set across every skill that surfaces this bucket. Default is Apply. `Skip` covers both "no, leave it" and "defer to a follow-up". The LLM does not present timing as a separate option because the question being asked is binary apply-or-not, with deferral expressed as Skip.
+
+**Needs human judgment.** Genuinely requires human input. The decision the human is making is "which approach", not "yes or no".
+
+Route to this bucket when any of these hold:
+
+- Multiple valid resolutions exist and the LLM cannot pick between them from first principles.
+- Missing product / UX / domain context the LLM cannot derive.
+- A real tradeoff that depends on user priorities, not facts.
+- Validation passes did not converge (low confidence in the finding itself).
+- The fix changes a contract in a way that requires a policy call.
+
+**Decision shape: bespoke options per finding.** The skill must enumerate concrete branches: the actual design alternatives, or a specific question with concrete answers. Examples of well-shaped options:
+
+- "Validation could be strict (reject) or lenient (coerce). Which fits the contract?" → `Strict reject` / `Lenient coerce` / `Strict but log coerce path`
+- "Retry policy on partial success is undefined. Which behavior do you want?" → `Retry full operation` / `Retry only the failed sub-step` / `Fail fast`
+- "Endpoint visibility: public or internal?" → `Public` / `Internal` / `Mixed (specify in Other)`
+
+Generic timing options (`Address now` / `Defer to follow-up` / `Dismiss` / `Discuss first`) are **forbidden** in this bucket. If the only honest decision shape is timing, the finding does not belong here; it belongs in Auto-applicable (just do it) or Needs sign-off (Apply with the LLM's recommendation as the default; Skip covers the "later / dismiss" cases).
+
+The auto-added "Other" option exists for edge cases the LLM did not enumerate. The LLM's job is to enumerate the obvious branches; "Other" is the escape hatch, not the default.
+
+**Forcing function.** When drafting options for a finding, if you find yourself writing "now / later / dismiss", stop. Re-route the finding. If the LLM has a single recommended fix, it belongs in Needs sign-off and the options collapse to `Apply / Skip / Modify`. If the LLM does not have a single recommended fix, the bucket-3 options must be the *actual* alternatives the human is choosing between, not timing labels. A bucket-3 finding with generic timing options is a misclassified bucket-2 finding.
+
+**Presentation.** Skills using the categorization present these as **three tables in fixed order**: Auto-applicable, Needs sign-off, Needs human judgment. If any bucket is empty, the table still appears with a single `none` row (anti-silent-omission guard, same purpose as the canonical lens-coverage table).
 
 ### Refactor Instinct
 
@@ -203,13 +236,15 @@ Guiding principle: **small, continuous refactors prevent large, breaking ones.**
 - Do not invent abstractions for hypothetical future requirements. Three similar lines is fine; demanding a helper for them is noise.
 
 ### Review Workflows
-There are five distinct review workflows, each with a corresponding slash command:
+There are seven review workflows, each with a corresponding slash command:
 
 1. **Self-review** (`/self-review`): Comprehensive code review of the feature branch against main. Review, validate for false positives, iterate until clean, then push and create a draft PR.
-2. **Polish** (`/polish`): Autonomous loop of `/self-review`'s discovery + validation, applying only Auto-applicable items (tool-grounded, mechanical, no behavior change, validation passes converged). Each iteration drains the Auto-applicable bucket and lets Needs human attention items accumulate; the loop only hands off when no Auto-applicable items remain (surfacing the Needs human attention items at that point) or any safety condition fires. Local-only: no push, no PR. Use as a finishing pass before `/self-review` opens the PR.
-3. **Copilot review** (`/copilot-review`): Address unresolved GitHub Copilot review threads on the current PR. Fetch threads via GraphQL, reproduce each issue when relevant, design our own fix (do not trust Copilot's recommendation), validate via the three-pass rigor, present findings as a table, then implement test-first when applicable, comment, and resolve threads via GraphQL.
-4. **Copilot pairing** (`/copilot-pairing`): Same rigor as `/copilot-review`, but loops autonomously: address Copilot's threads, push, re-request review, wait for Copilot's response, repeat until Copilot has no new comments. Hard stop conditions (ambiguity, scope creep, test failure, security-sensitive code, loop detection, iteration cap of 10) hand control back to the human.
-5. **Peer review** (`/peer-review`): Address unresolved peer review threads on the current PR. Same validation process as Copilot review, but responses must sound natural, human, and match the user's communication style.
+2. **Polish** (`/polish`): Autonomous loop of `/self-review`'s discovery + validation, applying only Auto-applicable items (tool-grounded, mechanical, no behavior change, validation passes converged). Each iteration drains the Auto-applicable bucket and lets the other two buckets accumulate; the loop only hands off when no Auto-applicable items remain (surfacing the Needs sign-off and Needs human judgment items at that point) or any safety condition fires. Local-only: no push, no PR. Use as a finishing pass before `/self-review` opens the PR.
+3. **Panel review** (`/panel-review`): Same shape as `/self-review` but routes Discovery Rigor and Validation Rigor through configurable external backends (OpenAI Codex CLI for ChatGPT Enterprise users, local Ollama models like Qwen2.5-Coder and DeepSeek-R1) so the variance does not come exclusively from the active Claude session. Pluggable `--backends` flag with profile-aware defaults (work repos default to Codex; personal repos default to local models). Intended to replace `/copilot-review` for cases where GitHub Copilot quota is the bottleneck.
+4. **Panel pairing** (`/panel-pairing`): Autonomous loop of `/panel-review`, same shape as `/copilot-pairing` minus all GitHub-Copilot-specific machinery (no bot detection, no GraphQL re-request, no 10-minute poll). Iterates until convergence (two consecutive iterations with zero new valid findings) or a safety condition fires; iteration cap 15. Intended to replace `/copilot-pairing`.
+5. **Peer review** (`/peer-review`): Address unresolved peer review threads on the current PR. Same validation process as `/copilot-review`, but responses must sound natural, human, and match the user's communication style.
+6. **Copilot review** (`/copilot-review`): Address unresolved GitHub Copilot review threads on the current PR. Fetch threads via GraphQL, reproduce each issue when relevant, design our own fix (do not trust Copilot's recommendation), validate via the three-pass rigor, present findings as a table, then implement test-first when applicable, comment, and resolve threads via GraphQL. **Transitional**, kept active during the `/panel-*` proving period and retired in a follow-up PR.
+7. **Copilot pairing** (`/copilot-pairing`): Same rigor as `/copilot-review`, but loops autonomously: address Copilot's threads, push, re-request review, wait for Copilot's response, repeat until Copilot has no new comments. Hard stop conditions (ambiguity, scope creep, test failure, security-sensitive code, loop detection, iteration cap of 10) hand control back to the human. **Transitional**, kept active during the `/panel-pairing` proving period and retired in a follow-up PR.
 
 For reviewing **someone else's** PR (not your own), use `/code-review` instead. It checks out the PR, applies the same three-pass validation rigor, and drafts comments for the user to submit manually.
 

--- a/roles/osx/files/CLAUDE.md
+++ b/roles/osx/files/CLAUDE.md
@@ -212,7 +212,7 @@ The auto-added "Other" option exists for edge cases the LLM did not enumerate. T
 
 **Forcing function.** When drafting options for a finding, if you find yourself writing "now / later / dismiss", stop. Re-route the finding. If the LLM has a single recommended fix, it belongs in Needs sign-off and the options collapse to `Apply / Skip / Modify`. If the LLM does not have a single recommended fix, the bucket-3 options must be the *actual* alternatives the human is choosing between, not timing labels. A bucket-3 finding with generic timing options is a misclassified bucket-2 finding.
 
-**Presentation.** Skills using the categorization present these as **three tables in fixed order**: Auto-applicable, Needs sign-off, Needs human judgment. If any bucket is empty, the table still appears with a single `none` row (anti-silent-omission guard, same purpose as the canonical lens-coverage table).
+**Presentation.** Skills using the categorization present these as **three tables in fixed order**: Auto-applicable, Needs sign-off, Needs human judgment. If any bucket is empty, the table still appears with a single `none` row (anti-silent-pruning guard, same purpose as the canonical lens-coverage table).
 
 ### Refactor Instinct
 

--- a/roles/osx/files/claude/commands/code-review.md
+++ b/roles/osx/files/claude/commands/code-review.md
@@ -64,7 +64,7 @@ Drop or downgrade items where the three passes do not converge. We are leaving c
 
 Lens-coverage table from CLAUDE.md `Discovery Rigor (Issue Identification)` first. Then findings grouped into four severity tiers, each as its own table in fixed order: Blockers, Concerns, Suggestions, Nits. Every tier table always appears; if a tier is empty, print a single `none` row so the empty tier is visible (same anti-silent-pruning guard as the lens-coverage table).
 
-`/code-review` does **not** use the Auto-applicable / Needs human attention split (per CLAUDE.md `Finding Categorization`). That split exists as a loop boundary for `/polish` and a prep step for `/self-review`'s local apply loop. `/code-review` only drafts comments for me to submit, so the relevant question is "how important is this and what comment do I post", not "can a robot apply this".
+`/code-review` does **not** use the three-bucket categorization (Auto-applicable / Needs sign-off / Needs human judgment) per CLAUDE.md `Finding Categorization`. That split exists as a loop boundary for `/polish` and `/panel-pairing`, and as a prep step for `/self-review`, `/panel-review`, `/peer-review`, and `/copilot-review`'s local apply loops. `/code-review` only drafts comments for me to submit, so the relevant question is "how important is this and what comment do I post", not "can a robot apply this".
 
 **Blockers** (must address before merge: correctness bugs, security issues, broken tests, missing critical pieces):
 

--- a/roles/osx/files/claude/commands/copilot-review.md
+++ b/roles/osx/files/claude/commands/copilot-review.md
@@ -106,23 +106,34 @@ If a column is not useful for the current PR (or you want a different cut), say 
 **Adjacent-findings output (from step 4's Discovery Rigor pass).** Always emit:
 
 1. The canonical lens-coverage table from CLAUDE.md `Discovery Rigor (Issue Identification)`, scoped to the files / hunks Copilot reviewed (not the full diff).
-2. **Two adjacent-findings tables**, split per CLAUDE.md `Finding Categorization`. Both always appear; print a single `none` row when a bucket is empty.
+2. **Three adjacent-findings tables**, split per CLAUDE.md `Finding Categorization`. All three always appear; print a single `none` row when a bucket is empty.
 
 **Auto-applicable adjacent findings** (`/polish` could handle these autonomously on the same branch):
 
 | # | Lens | File:Line | Finding | Rule cited | Validation passes | Recommendation |
 |---|---|---|---|---|---|---|
 
-**Needs human attention adjacent findings**:
+**Needs sign-off adjacent findings** (LLM has a single recommended fix, but the change warrants approval before landing):
 
-| # | Lens | File:Line | Finding | Severity | Confidence | Validation passes | Recommendation |
+| # | Lens | File:Line | Finding | Proposed fix | Why sign-off | Validation passes | Recommendation |
 |---|---|---|---|---|---|---|---|
 
-No `Draft comment` column on either: adjacent findings are surfaced for the user to decide on, not posted as standalone PR comments. If the user chooses to address one, fold the change into this iteration's commit. In `/copilot-pairing`, the auto-execution invariant prevents auto-fixing adjacent findings; they are only surfaced for human review.
+**Needs human judgment adjacent findings** (multiple valid resolutions, missing context, or low confidence):
+
+| # | Lens | File:Line | Finding | Why ambiguous | Confidence | Validation passes | Options |
+|---|---|---|---|---|---|---|---|
+
+No `Draft comment` column on any of the three: adjacent findings are surfaced for the user to decide on, not posted as standalone PR comments. If the user chooses to address one, fold the change into this iteration's commit. In `/copilot-pairing`, the auto-execution invariant prevents auto-fixing adjacent findings; they are only surfaced for human review.
 
 ### 6. Address items: solution validated with two or three test angles
 
-Follow the standard review workflow (let me choose: all at once, one by one, batched decisions, or clustered decisions, with progress tracking). For batched mode, the `/copilot-review` option set is **Address now / Defer to follow-up / Dismiss / Discuss first** (with auto-added "Other" for custom decisions). For clustered mode, the cluster-wide option set is **Address all / Defer all to follow-up / Dismiss all / Pick individually** (with "Pick individually" dropping into batched mode for that cluster only).
+Follow the standard review workflow (let me choose: all at once, one by one, batched decisions, or clustered decisions, with progress tracking). Option sets are derived from each thread's bucket per CLAUDE.md `Finding Categorization` (applies to both the main Copilot-thread table and the adjacent findings):
+
+- **Auto-applicable**: apply the mechanical fix; the reply is the terse "Done in `<sha>`" template.
+- **Needs sign-off**: `Apply / Skip / Modify` in batched mode (Apply lands the fix + posts the drafted reply; Skip drops the thread; Modify adjusts before landing); `Apply all / Skip all / Pick individually` in clustered mode.
+- **Needs human judgment**: bespoke options per thread (the actual response branches; generic timing options are forbidden); cluster-wide options reflect the shared axis when clustering applies.
+
+The classification column from the main table (`valid` / `false positive` / `low-confidence` / `adjacent finding`) drives where a thread lands: `valid` items with a clear fix go to Needs sign-off (or Auto-applicable when the fix is mechanical and tool-grounded), `false positive` to Needs sign-off (dismissal reply requires approval), `low-confidence` to Needs human judgment.
 
 For **valid** items that affect runtime behavior, apply the canonical rigor in CLAUDE.md `Validation Rigor (Solutions)`:
 

--- a/roles/osx/files/claude/commands/panel-pairing.md
+++ b/roles/osx/files/claude/commands/panel-pairing.md
@@ -1,0 +1,136 @@
+Iterate `/panel-review` autonomously, applying only Auto-applicable items, until none remain. Hand control back when no Auto-applicable items are left to drain (surfacing any Needs sign-off and Needs human judgment items in the final tables) or any safety condition fires.
+
+Same Discovery + Validation rigor as `/panel-review`, executed on autopilot, with hard stop conditions baked in for safety.
+
+## When to use
+
+You want the `/copilot-pairing` shape (review, address, push, re-review, repeat) but with non-Anthropic model backends doing the discovery instead of GitHub Copilot. Common cases:
+
+- Copilot quota is exhausted for the month and you still want pairing-style autonomous draining.
+- You want backend variance (different training distributions) without GitHub's per-request billing model.
+- You are starting from a branch with no PR yet and want pairing-style cleanup before opening one.
+
+`/panel-pairing` is the autonomous counterpart to `/panel-review`. It only auto-applies items in the Auto-applicable bucket (CLAUDE.md `Finding Categorization`); Needs sign-off and Needs human judgment items are surfaced for human review when the loop exits, same boundary `/polish` uses for self-review. For interactive review of all buckets, use `/panel-review` directly.
+
+## Pre-flight (once per run)
+
+1. **Identify base branch and capture the diff** (same as `/panel-review` pre-flight 1).
+2. **(Optional) Jira ticket** (same as `/panel-review` pre-flight 2).
+3. **Detect repo profile** (same as `/panel-review` pre-flight 3).
+4. **Resolve the backend set.** Same logic as `/panel-review` pre-flight 4, but with different profile defaults tuned for autonomous loops (more variance, you walk away during iterations):
+
+   | Profile | Default backends |
+   |---|---|
+   | work | `codex`, `qwen-coder` |
+   | personal | `qwen-coder`, `deepseek-r1` |
+
+   `--backends` overrides. `copilot` is opt-in only.
+
+5. **Verify each backend** (same as `/panel-review` pre-flight 5; stop with the same install / auth messages on any failure).
+6. **Initialize iteration counter** = 0.
+7. **Confirm the working tree is clean.** `git status --porcelain` must be empty before the loop starts. Uncommitted changes interfere with per-iteration commit boundaries and make rollback ambiguous. If the tree is dirty, stop and ask the user to commit or stash first.
+8. **Confirm the branch has an upstream**, or that the first push will create one. `git rev-parse --abbrev-ref --symbolic-full-name @{u}` succeeds when an upstream exists; if it fails, the first push in step (e) uses `git push -u origin <branch>` instead of `git push origin <branch>`. Do not pre-push at pre-flight; the first iteration's push handles it.
+
+## Iteration loop
+
+For each iteration (cap = **15**):
+
+**Cap check (run at the start of every iteration, before step (a)).** Read the iteration counter (initialized to 0 in pre-flight step 6; incremented in step (f)). If the counter has reached **15**, do not enter step (a). Trigger the **Iteration cap** stop condition and hand control back. This is the only place the cap is enforced; the increment in (f) does not enforce it itself.
+
+### a. Generate + validate findings
+
+Run `/panel-review` steps 1-5 in full: project tooling sweep, parallel backend discovery pass, merge + dedupe, self-critique pass, three-pass Validation Rigor on every finding.
+
+Be more conservative than in `/panel-review` because nobody is checking the categorization in real time. **When in doubt, route to Needs sign-off or Needs human judgment, never Auto-applicable.** False negatives (a real Auto-applicable item routed to human) are cheap, costing one extra iteration. False positives (a judgment item auto-applied) silently corrupt the branch.
+
+### b. Categorize per `Finding Categorization`
+
+Each finding lands in exactly one bucket: Auto-applicable, Needs sign-off, or Needs human judgment. The four Auto-applicable conditions and disqualifiers are in CLAUDE.md `Finding Categorization`.
+
+### c. Decide loop fate
+
+Branch on the bucket counts:
+
+- **All three buckets empty.** Success. Exit the loop. Print the final summary noting "panel converged, no findings remain". Do not commit (nothing changed this iteration).
+- **Auto-applicable empty, Needs sign-off or Needs human judgment non-empty.** Stop. Trigger **Human attention required** stop condition. Print the latest tables (Auto-applicable empty, both other buckets populated) and hand control back. Do not push, do not commit, do not auto-apply anything from the populated buckets.
+- **Auto-applicable non-empty, regardless of the other buckets.** Proceed to step (d). Items in the other buckets are re-evaluated next iteration; the user addresses them after `/panel-pairing` hands off.
+
+### d. Apply Auto-applicable items (solution validation rigor)
+
+For each Auto-applicable item, apply CLAUDE.md `Validation Rigor (Solutions)` even though the fix is mechanical:
+
+1. **Pre-fix tool run.** Run the cited tool against the file(s) and confirm the rule actually fires on the current code. If it does not (e.g., the rule was already silenced, the file changed since discovery), drop the item and continue. Do not apply a fix for a rule that does not currently fire.
+2. **Apply the fix.**
+3. **Post-fix tool run.** Run the cited tool again against the same file(s) and confirm the rule no longer fires.
+4. **Wider check.** Run the broader project test suite, linters, and type-checkers. Any failure (even a pre-existing one we surface for the first time) triggers the **Test failure** stop condition.
+
+For non-testable fixes (formatting, typos in comments, doc adjustments), substitute review angles per the canonical doctrine in CLAUDE.md.
+
+### e. Commit and push
+
+Order matters: land the code, then move on.
+
+1. `git add` only the files actually changed (never `git add -A`).
+2. Commit with a message of the form `chore(panel): iter N, <short summary>` (e.g., `chore(panel): iter 1, drop unused imports and fix typos`).
+3. Push: `git push origin <branch>` (or `git push -u origin <branch>` on the first iteration if pre-flight step 8 detected no upstream). **Never** `--force`, `--force-with-lease`, or any rebase flag. If the push fails on a hook (pre-push test, security check, lefthook stage, etc.), trigger the **Push hook failure** stop condition; do not silently retry, do not bypass with `--no-verify`, and do not "fix" unrelated test flakes inside this branch.
+4. Do **not** amend, squash, or rebase. Each iteration is its own commit so you can inspect and revert per-iteration if needed.
+
+### f. Iteration summary
+
+Print a short summary:
+
+- Iteration N / cap.
+- Backends invoked + wall-clock per backend (so you can see which were slow / fast).
+- Counts: Auto-applicable applied, Needs sign-off surfaced, Needs human judgment surfaced, dropped at step (d.1) (rule no longer fires).
+- Files touched.
+- Commit SHA.
+- Test command run + result.
+
+This is what you scroll back through to audit the run. Then increment iteration counter and loop to (a).
+
+## Stop conditions (mandatory human handoff)
+
+If any condition fires, **stop**. Print the latest tables, name the condition, and wait for the user. Do not commit further, do not push, do not invoke backends again.
+
+| Condition | Trigger |
+|---|---|
+| **Human attention required** | Step (c) found Needs sign-off or Needs human judgment items and Auto-applicable is empty. The normal path to handoff. |
+| **Test failure** | Any test, linter, type-check, or formatter failed at step (d.4), including pre-existing failures surfaced for the first time. |
+| **Push hook failure** | `git push origin <branch>` (step e.3) failed on a hook (pre-push test, security check, lefthook stage, etc.). Diagnose whether the failure traces to this iteration's diff or to pre-existing / unrelated state, surface the diagnosis, and hand off. Do not silently retry, do not bypass with `--no-verify`, and do not "fix" unrelated test flakes inside this branch. |
+| **Loop detection** | A substantively similar finding (same file, same root issue, regardless of which backend surfaced it) has been raised in two consecutive iterations after the prior iteration applied a fix. Indicates the fix is not actually addressing the underlying issue, or that backends are hallucinating consistent false positives. |
+| **Backend failure** | A backend invocation in step (a) failed (timeout, parse error, model error, auth lost mid-run). Stop rather than silently dropping the backend; the user invoked this skill specifically for that backend's variance. |
+| **Iteration cap** | 15 iterations completed without convergence. |
+| **Ambiguity** | A finding is borderline between buckets and the bright-line conditions cannot be confidently asserted across two consecutive iterations. Hand off rather than guessing. |
+| **Security-sensitive** | Any Auto-applicable candidate touches auth, secrets, crypto, permissions, IAM, SQL/shell construction, or sandbox boundaries. Per the categorization disqualifiers, the item should already be Needs sign-off; if for any reason it landed in Auto-applicable, stop. |
+| **Migrations / data / destructive ops** | Same as above for schema migrations, backfills, deletes, drops, anything irreversible. |
+| **Dirty working tree** | Pre-flight step 7 found uncommitted changes. Stop before iteration starts. |
+| **High false-positive ratio** | At least 3 items in the iteration AND more than half were dropped at step (d.1) (rule no longer fires). Backends may be misreading the diff or hallucinating tool output. Pause for re-alignment rather than spamming useless commits. |
+
+## Auto-execution invariants
+
+These hold at every step:
+
+- **Never** address a Needs sign-off or Needs human judgment item, even if it looks easy. Those are reserved for the post-loop human pass via `/panel-review` or manual fixes.
+- **Never** route a finding to Auto-applicable without a specific rule citation. "I am sure this is a typo" does not qualify; "ruff F401: imported but unused" does. The rule citation must come from the project tooling run in step (a), not from a backend's free-form recommendation.
+- **Never** silently drop a backend that failed in step (a). The user picked the backend set; partial runs hide which variance source went missing.
+- **Never** modify CI configuration, `.env`, secrets, or lockfiles, even on a tool's recommendation.
+- **Never** push `--force`, `--force-with-lease`, or amend / squash / rebase commits already pushed.
+- **Never** silently retry a failed `git push` or bypass with `--no-verify`. Trigger the **Push hook failure** stop condition with a brief diagnosis instead.
+- **Never** create a PR. `/panel-pairing` is a fix-drain loop; PR creation is `/self-review` or `/panel-review`'s job after the loop hands off.
+- **Never** post anything to chat platforms, tickets, or any remote system.
+- **Never** skip step (d.4) (wider test / lint / type-check run). A "simple" fix that breaks an unrelated test is the failure mode this guards against.
+- **Never** trust the iteration counter alone for cap enforcement; verify at the top of the iteration via the explicit cap check.
+
+## After the loop
+
+When `/panel-pairing` exits (success, human handoff, or any other stop condition), the next move is the user's:
+
+- On success ("panel converged, no findings remain"): consider running `/self-review` or `/panel-review` to do a final pass and open a PR.
+- On Human attention required: address the surfaced Needs sign-off and Needs human judgment items by running `/panel-review` interactively (or `/self-review` if you want Claude-only review of the remainder). After they are resolved, re-run `/panel-pairing` to drain anything new and open a PR.
+- On Test failure, Push hook failure, or other safety stops: investigate the named condition. `/panel-pairing` does not auto-resume; the user explicitly re-invokes after the underlying issue is understood.
+
+## Maintenance
+
+After completing the workflow (or stopping), check if any part of these instructions seems outdated, incorrect, or misaligned with current tooling: backend CLI command syntax changes, changes to `Finding Categorization` thresholds, new auto-fix tools that should be tool-grounded by default, drift from `/panel-review`'s discovery shape (which `/panel-pairing` follows), or stop-condition gaps revealed by a real run. If something looks off, flag it and offer a ready-to-use prompt to paste into a new dotfiles session to update this command.
+
+$ARGUMENTS

--- a/roles/osx/files/claude/commands/panel-review.md
+++ b/roles/osx/files/claude/commands/panel-review.md
@@ -1,0 +1,139 @@
+Do a comprehensive code review of the current feature branch using configurable non-Anthropic model backends, so the variance does not come exclusively from this Claude session.
+
+Same Discovery + Validation rigor as `/self-review`. The backends provide the discovery angle (different training distributions catch what Claude would miss); validation is grounded locally in this session.
+
+## When to use
+
+You want a `/self-review` shape but with one or more external models contributing findings. Common cases:
+
+- ChatGPT Enterprise users on a work repo (Codex CLI as a fast frontier-OpenAI backend).
+- Personal repos (local Ollama models from different lineages: Alibaba's Qwen2.5-Coder, DeepSeek-R1's reasoning lens).
+- Any time you want a non-Anthropic angle without paying GitHub Copilot's per-request quota.
+
+For autonomous looping (review, apply, push, re-review until convergence), use `/panel-pairing` instead. For the standard Claude-only review, use `/self-review`.
+
+## Pre-flight (once per run)
+
+1. **Identify base branch and capture the diff** (same as `/self-review` step 1).
+2. **(Optional) Jira ticket** (same as `/self-review` step 2).
+3. **Detect repo profile.** Work or personal, driven by the current repo's GitHub org:
+
+   ```bash
+   case "$(git remote get-url origin 2>/dev/null)" in
+     *[:/]SymmetrySoftware/*|*[:/]Gusto/*) echo work ;;
+     *) echo personal ;;
+   esac
+   ```
+
+4. **Resolve the backend set.** If `$ARGUMENTS` contains `--backends a,b,c`, use those (comma-separated). Otherwise apply the profile default:
+
+   | Profile | Default backends |
+   |---|---|
+   | work | `codex` |
+   | personal | `qwen-coder` |
+
+   Supported backends: `codex`, `qwen-coder`, `deepseek-r1`, `copilot`. `copilot` is **opt-in only** via `--backends`; do not auto-include it (the GitHub quota is the original constraint and including it implicitly defeats the point).
+
+5. **Verify each backend.** Stop with a specific install / auth message if any fails; do not silently drop a backend (the user expects the variance the backend provides).
+
+   - `codex`: `command -v codex` must succeed; `codex auth status` (or equivalent: query the codex CLI's own readiness probe) must report an authenticated session. If not authed, stop with `Codex CLI needs auth; run 'codex login'`. If not installed, stop with `Codex CLI not installed; mise run osx will install via Brewfile cask 'codex'`.
+   - `qwen-coder` / `deepseek-r1`: `curl -sf http://localhost:11434/api/tags` must return a body containing the model name (`qwen2.5-coder:32b` or `deepseek-r1:32b`). If the API does not respond, stop with `Ollama service not running; brew services start ollama`. If the model is missing, stop with `Model not pulled; ollama pull <name>` (the dotfiles Ansible task pulls both by default; missing means an opt-out happened).
+   - `copilot`: `gh copilot --help` must succeed and the account must have quota. Stop if `gh` is not authenticated or `gh copilot` returns a quota-exhausted error.
+
+## Steps
+
+### 1. Run project tooling once
+
+Linters, formatters, type checkers, static analyzers, complexity / duplication meters, dead-code detectors, security scanners. Discover via `lefthook.yml`, CI workflows, `mise.toml` tasks, language config files, and the SessionStart `tool-discovery` summary if present in this session's context. Capture the output; it becomes shared input for every backend so all of them ground their findings the same way (this is what makes "tool-grounded" survive backend variance).
+
+### 2. Backend discovery pass
+
+For each backend in the resolved set, invoke it **once** with the full diff, the tooling output from step 1, and a lens-walk prompt covering all 9 canonical lenses from CLAUDE.md `Discovery Rigor (Issue Identification)`. Each invocation is independent; run them in parallel (separate `Bash` tool calls in the same response) when possible.
+
+**Prompt structure to send each backend** (adapt the literal wording per backend's preferences; the substance is what matters):
+
+```
+Review this diff. Walk every lens below and report findings for each. Severity-pruning is forbidden: a small doc nit and a critical bug must both be reported in the same pass. If a lens has no findings, return `none` with a one-line reason.
+
+Lenses:
+1. Correctness, logic, edge cases (null, empty, max size, concurrency, off-by-one, error paths)
+2. Security (injection, auth, data exposure, secret handling, untrusted input)
+3. Error handling and failure modes
+4. Performance (allocation, IO, complexity, hot paths)
+5. Concurrency / state (races, idempotency, ordering, retries)
+6. Naming, readability, structure (only flag when this PR worsens it)
+7. Documentation (docstrings, READMEs, ADRs, config docs)
+8. Tests / verification (coverage of new behavior, missing failing-case tests)
+9. Cross-file consistency (broken invariants, sibling-pattern drift)
+
+Output format: a Markdown table with columns Lens, File:Line, Finding, Rule cited (if any), Severity. One row per finding.
+
+Project tooling output (shared with all backends):
+<tooling output from step 1>
+
+Diff:
+<full diff or relevant slice>
+```
+
+**Per-backend invocation patterns** (verify exact flags on first use; this is illustrative):
+
+- **codex**: `codex exec "<prompt>"` (or the equivalent flag set; the CLI may require `--model` or similar). Codex returns text on stdout; capture and parse the table.
+- **qwen-coder**: `ollama run qwen2.5-coder:32b "<prompt>"` (or POST to `http://localhost:11434/api/generate` for streaming control). Expect 2-4 minutes wall-clock per invocation on an M1 Max.
+- **deepseek-r1**: `ollama run deepseek-r1:32b "<prompt>"`. Slower than Qwen-Coder because of the reasoning chain; expect 4-8 minutes.
+- **copilot**: route through `gh copilot` or the chosen Copilot CLI; specifics depend on which CLI variant is current.
+
+If a backend invocation fails (timeout, parse error, model error), do **not** silently drop it: stop the run and surface the failure. The user invoked this skill specifically for the variance that backend provides; partial runs hide the fact that one source of variance went missing.
+
+### 3. Merge backend findings
+
+Build one normalized list:
+
+- Dedupe by `(file, line, root issue)`. A finding flagged by multiple backends becomes one row with all backend labels tagged in the row.
+- Tag every row with which backend(s) surfaced it. This is what lets you see, over time, which backends earn their keep on your code.
+- A finding hitting two lenses (one backend assigned `Correctness`, another assigned `Error handling`) gets one row with both lens labels.
+
+Apply the **review-mode refactor instinct** filter (CLAUDE.md `Refactor Instinct`): drop refactor flags not anchored in tool output that do not represent this-PR-makes-it-worse.
+
+### 4. Self-critique pass (mandatory)
+
+Re-scan the merged list with the assumption that it is incomplete. Add what feels under-represented. This is the same anti-silent-pruning guard the canonical Discovery Rigor specifies; backends can self-prune within their own context windows the same way a single coordinator agent can, so the critique pass is load-bearing even with multiple backends.
+
+### 5. Validate every finding with the three-pass rigor
+
+Apply CLAUDE.md `Validation Rigor (Issue Identification)` in full, locally in this Claude session, on every backend-surfaced finding:
+
+- **Pass 1: direct reproduction.** Reproduce runtime claims (failing test, repro script, concrete-input trace).
+- **Pass 2: orthogonal angle.** Callers, related paths, project conventions, sibling implementations, existing test coverage.
+- **Pass 3: outside-in angle.** `git log` / `git blame`, repo-wide search, official docs, library source / tests, deepwiki MCP, GitHub issues, RFCs, web search for text or research-based claims.
+
+Drop or downgrade items where the three passes do not converge. Backends produce findings; validation grounds them. A finding that survives three passes with high confidence routes to Auto-applicable or Needs sign-off per `Finding Categorization`; lower confidence or genuinely ambiguous resolutions route to Needs human judgment.
+
+### 6. Present results
+
+Lens-coverage table from CLAUDE.md `Discovery Rigor (Issue Identification)` first (one row per lens, counts merged across backends, with `none` / `n/a` rows where applicable). Then the **three findings tables in fixed order** per `Finding Categorization`: Auto-applicable, Needs sign-off, Needs human judgment. Each table always appears; empty buckets get a single `none` row.
+
+Findings tables include a `Backend(s)` column so you can see which model surfaced what. Suggested columns: `# | Lens | File:Line | Finding | Rule cited | Backend(s) | Validation passes | Confidence | Recommendation`. Drop columns that are uniformly empty.
+
+### 7. Follow the standard review workflow
+
+Per CLAUDE.md `Code & PR Reviews`: ask which mode (a/b/c/d) and apply progress tracking. Option sets are derived from the bucket per `Finding Categorization`:
+
+- **Auto-applicable**: no question, apply with solution validation.
+- **Needs sign-off**: standard `Apply / Skip / Modify` option set across batched and clustered modes.
+- **Needs human judgment**: bespoke options per finding (skill authors the actual decision branches; generic timing options are forbidden, see `Finding Categorization` forcing function).
+
+When implementing fixes, apply CLAUDE.md `Validation Rigor (Solutions)`: targeted failing test → fix → confirm pass; wider check (project tests, linters, type checkers); edge / integration / manual when relevant. For non-testable changes, substitute review angles and note why no test was added.
+
+### 8. Documentation check
+
+Before committing, verify documentation affected by the changes is up to date: docstrings, READMEs, requirements / design docs, task / planning files, configuration docs, any prose referencing changed code. Search the repo for references to changed function names, feature names, or concepts. Include doc issues in the review findings alongside code issues.
+
+### 9. Commit, push, PR
+
+After all items are addressed, commit. Then if the review found nothing substantive (or after everything is addressed), offer to push and handle the PR, gracefully reusing an existing one if present (same as `/self-review` step 9, including the push-hook failure handling that forbids `--no-verify`).
+
+## Maintenance
+
+After completing the workflow, check if any part of these instructions seems outdated or misaligned with current tooling: backend CLI command syntax changes (Codex flags, Ollama API), new backend options worth adding, changes to model names / sizes, or drift from `/self-review`'s discovery shape (which this skill mirrors). If something looks off, flag it and offer a ready-to-use prompt to paste into a new dotfiles session to update this command.
+
+$ARGUMENTS

--- a/roles/osx/files/claude/commands/panel-review.md
+++ b/roles/osx/files/claude/commands/panel-review.md
@@ -66,7 +66,7 @@ Lenses:
 8. Tests / verification (coverage of new behavior, missing failing-case tests)
 9. Cross-file consistency (broken invariants, sibling-pattern drift)
 
-Output format: a Markdown table with columns Lens, File:Line, Finding, Rule cited (if any), Severity. One row per finding.
+Output format: ONLY a Markdown table with columns Lens, File:Line, Finding, Rule cited (if any), Severity. No preamble (including `<think>` blocks, "Thinking..." traces, or any reasoning model intermediate output). No commentary, observations, or summaries after the table. The table is the entire response. One row per finding; if a lens has zero findings, emit a row like `| Documentation | n/a | none (one-line reason) | | n/a |` so the empty lens stays visible.
 
 Project tooling output (shared with all backends):
 <tooling output from step 1>
@@ -78,8 +78,15 @@ Diff:
 **Per-backend invocation patterns** (verify exact flags on first use; this is illustrative):
 
 - **codex**: `codex exec "<prompt>"` (or the equivalent flag set; the CLI may require `--model` or similar). Codex returns text on stdout; capture and parse the table.
-- **qwen-coder**: `ollama run qwen2.5-coder:32b "<prompt>"` (or POST to `http://localhost:11434/api/generate` for streaming control). Expect 2-4 minutes wall-clock per invocation on an M1 Max.
-- **deepseek-r1**: `ollama run deepseek-r1:32b "<prompt>"`. Slower than Qwen-Coder because of the reasoning chain; expect 4-8 minutes.
+- **qwen-coder** and **deepseek-r1** (Ollama): **prefer the HTTP API** for programmatic invocation:
+  ```bash
+  curl -s http://localhost:11434/api/generate \
+    -d "$(jq -nR --arg model 'qwen2.5-coder:32b' --rawfile prompt /tmp/panel-review-prompt.txt \
+      '{model: $model, prompt: $prompt, stream: false}')" \
+    | jq -r '.response'
+  ```
+  The API returns clean JSON with the response under `.response`. `ollama run <model> "<prompt>"` works as a fallback but emits ANSI escape codes (cursor moves, line clears) intended for an interactive TTY; even when piped, those leak into the output and require post-processing (`sed -E 's/\x1b\[[0-9;]*[a-zA-Z]//g' | tr -d '\r'`). The HTTP API path avoids that entirely.
+- **Wall-clock estimates on M1 Max 32GB** (one model loaded at a time; Ollama swaps when the second one is invoked): `qwen-coder` ~5 min, `deepseek-r1` ~10 min (slower because of the reasoning chain). Two 32B models cannot stay resident together on 32GB RAM, so running both backends serializes in practice even if the orchestrator fires them in parallel.
 - **copilot**: route through `gh copilot` or the chosen Copilot CLI; specifics depend on which CLI variant is current.
 
 If a backend invocation fails (timeout, parse error, model error), do **not** silently drop it: stop the run and surface the failure. The user invoked this skill specifically for the variance that backend provides; partial runs hide the fact that one source of variance went missing.

--- a/roles/osx/files/claude/commands/peer-review.md
+++ b/roles/osx/files/claude/commands/peer-review.md
@@ -69,9 +69,9 @@ For each remaining thread, apply the canonical rigor in CLAUDE.md `Validation Ri
 
 Classify each as **valid**, **false positive**, **preference**, or **low-confidence** (passes did not converge; never guess). When the concern is a matter of preference, surface the trade-off rather than asserting correctness.
 
-### 5. Present the validated threads as two tables
+### 5. Present the validated threads as three tables
 
-Split per CLAUDE.md `Finding Categorization`. Both tables always appear; if a bucket is empty, print a single `none` row.
+Split per CLAUDE.md `Finding Categorization`. All three tables always appear; if a bucket is empty, print a single `none` row.
 
 **Auto-applicable** (the reviewer flagged something tool-grounded and mechanical; reply can be a terse "Done in `<sha>`"):
 
@@ -82,16 +82,22 @@ Split per CLAUDE.md `Finding Categorization`. Both tables always appear; if a bu
 - **Rule cited**: the linter / type-checker / formatter rule that confirms the reviewer's concern.
 - **Draft response**: short, polite. "Done in `<sha>`" or "Good catch, fixed in `<sha>`" is usually enough.
 
-**Needs human attention** (preference, design, refactor, ambiguity, low-confidence, anything that needs a real reply):
+**Needs sign-off** (LLM has a clear recommended response, but the change touches a public API / external interface / sensitive area, or the response is non-trivial and benefits from approval before posting):
 
-| # | Thread ID | File:Line | Reviewer's concern | What we found | Classification | Confidence | Validation passes | Recommendation | Draft response |
-|---|---|---|---|---|---|---|---|---|---|
+| # | Thread ID | File:Line | Reviewer's concern | What we found | Classification | Validation passes | Proposed action | Draft response |
+|---|---|---|---|---|---|---|---|---|
 
-- **What we found**: a one-line, plain-prose verdict from our investigation (the rationale that supports the `Classification` bucket).
-- **Classification**: valid / false positive / preference / low-confidence.
-- **Confidence**: high / medium / low.
-- **Recommendation**: implement fix / dismiss / defer to follow-up / acknowledge preference and explain trade-off / etc.
-- **Draft response**: literal reply you would post. See step 6 tone requirements (concise but not curt, acknowledges good points, no corporate speak, no em-dashes, sounds natural and human, written as if the user wrote it themselves).
+- **Classification**: valid / false positive / preference (with clear stance).
+- **Proposed action**: implement fix / dismiss / acknowledge preference with explanation. Single recommended action per finding.
+- **Draft response**: literal reply (subject to step 6 tone requirements). Default decision is `Apply`; `Skip` covers "don't post this reply" and `Modify` lets you adjust wording.
+
+**Needs human judgment** (genuinely ambiguous, low-confidence, multiple valid responses, or requires product / UX / domain context):
+
+| # | Thread ID | File:Line | Reviewer's concern | What we found | Why ambiguous | Confidence | Validation passes | Options |
+|---|---|---|---|---|---|---|---|---|
+
+- **Why ambiguous**: the specific reason the LLM cannot pick a response from first principles (multiple valid resolutions, missing context, tradeoff, low confidence from three-pass).
+- **Options**: the concrete branches the user is choosing between (per `Finding Categorization`'s per-finding option authoring rule). Bespoke per finding; generic timing options are forbidden.
 
 If a column is not useful for this PR, say so before printing the table and adjust. Optional add-ons worth considering: `Severity`, `Files touched by fix`, `Scope risk` (in-scope / out-of-scope).
 
@@ -99,7 +105,11 @@ No lens-coverage table here: this skill validates pre-existing human threads, it
 
 ### 6. Address items
 
-Follow the standard review workflow (let me choose: all at once, one by one, batched decisions, or clustered decisions, with progress tracking). For batched mode, the `/peer-review` option set is **Address now / Defer to follow-up / Dismiss / Discuss first** (with auto-added "Other" for custom decisions). For clustered mode, the cluster-wide option set is **Address all / Defer all to follow-up / Dismiss all / Pick individually** (with "Pick individually" dropping into batched mode for that cluster only).
+Follow the standard review workflow (let me choose: all at once, one by one, batched decisions, or clustered decisions, with progress tracking). Option sets are derived from each thread's bucket per CLAUDE.md `Finding Categorization`:
+
+- **Auto-applicable**: apply the mechanical fix and post the terse "Done in `<sha>`" reply after sign-off on the reply text (the underlying fix is mechanical, the human still owns the reply since it goes to another person).
+- **Needs sign-off**: `Apply / Skip / Modify` in batched mode (Apply lands the proposed action + drafted reply; Skip drops the thread without posting; Modify lets you tweak the wording before it lands); `Apply all / Skip all / Pick individually` in clustered mode.
+- **Needs human judgment**: bespoke options per thread (the actual response branches; generic timing options are forbidden); cluster-wide options reflect the shared axis when clustering applies.
 
 **Response tone requirements** (this is critical since we are replying to a person):
 - Concise but not curt

--- a/roles/osx/files/claude/commands/polish.md
+++ b/roles/osx/files/claude/commands/polish.md
@@ -1,19 +1,19 @@
-Iterate `/self-review` autonomously, applying only Auto-applicable items, until none remain. Hand control back when no Auto-applicable items are left to drain (surfacing any Needs human attention items in that final table) or any safety condition fires.
+Iterate `/self-review` autonomously, applying only Auto-applicable items, until none remain. Hand control back when no Auto-applicable items are left to drain (surfacing any Needs sign-off or Needs human judgment items in the final tables) or any safety condition fires.
 
 Same Discovery + Validation rigor as `/self-review`, executed on autopilot, with hard stop conditions baked in for safety.
 
 ## When to use
 
-You are nearly done with a branch and want to drain the trivial, tool-grounded fixes (linter rule violations, formatter output, type-checker errors, missing imports, unused variables, typos in comments, inferable type annotations) before opening a PR. Polish auto-applies items that meet the strict Auto-applicable definition in CLAUDE.md `Finding Categorization`; once the Auto-applicable bucket is empty (or any safety condition fires), it surfaces any Needs human attention items in the final iteration table and hands off.
+You are nearly done with a branch and want to drain the trivial, tool-grounded fixes (linter rule violations, formatter output, type-checker errors, missing imports, unused variables, typos in comments, inferable type annotations) before opening a PR. Polish auto-applies items that meet the strict Auto-applicable definition in CLAUDE.md `Finding Categorization`; once the Auto-applicable bucket is empty (or any safety condition fires), it surfaces any Needs sign-off or Needs human judgment items in the final iteration tables and hands off.
 
-When the toolchain is clean and the diff is uniformly inside a categorization disqualifier (e.g., entirely security-sensitive auth code), Polish will hand off on the first iteration with all findings in Needs human attention. The same first-iteration handoff happens when the project ships no tool that can ground a finding for the changed file types (e.g., a markdown-only diff in a project without a markdown linter), since condition 1 (tool-grounded) cannot hold. Both are the expected outcome, not a failure.
+When the toolchain is clean and the diff is uniformly inside a categorization disqualifier (e.g., entirely security-sensitive auth code), Polish will hand off on the first iteration with all findings in Needs sign-off or Needs human judgment. The same first-iteration handoff happens when the project ships no tool that can ground a finding for the changed file types (e.g., a markdown-only diff in a project without a markdown linter), since condition 1 (tool-grounded) cannot hold. Both are the expected outcome, not a failure.
 
-Polish does **not** create a PR. Run `/self-review` after Polish hands off, once you have addressed the Needs human attention items.
+Polish does **not** create a PR. Run `/self-review` after Polish hands off, once you have addressed the Needs sign-off or Needs human judgment items.
 
 ## Pre-flight (once per run)
 
 1. **Identify the base branch and capture diff baseline** (same as `/self-review` step 1).
-2. **(Optional) Fetch Jira ticket for context** (same as `/self-review` step 2). Used only as an extra lens during Discovery Rigor, not as a fix authority. Failing to satisfy an acceptance criterion is always Needs human attention.
+2. **(Optional) Fetch Jira ticket for context** (same as `/self-review` step 2). Used only as an extra lens during Discovery Rigor, not as a fix authority. Failing to satisfy an acceptance criterion is always Needs sign-off or Needs human judgment.
 3. **Initialize iteration counter** = 0.
 4. **Confirm the working tree is clean.** Polish requires `git status --porcelain` to be empty before it starts. Uncommitted changes interfere with the per-iteration commit boundary and make rollback ambiguous. If the tree is dirty, stop and ask the user to commit or stash first.
 
@@ -25,11 +25,11 @@ For each iteration (cap = **10**):
 
 ### a. Generate findings
 
-Apply `/self-review` step 3 (lens walk + tooling sweep + self-critique), then validate findings per `/self-review` step 4 (Validation Rigor). Full three-pass rigor is a **hard gate** only for findings that could be routed to Auto-applicable, since Polish will silently apply those and condition 4 of `Finding Categorization` requires converged validation. For findings that already fail one of conditions 1–3 (not tool-grounded, not mechanical, or user-observable change) and can therefore only land in Needs human attention, a **soft-floor pass** is enough: spot-check to drop clear false positives, then route to Needs human attention. The user finishes validation during their own review of those items, so spending three full passes on them is wasted work.
+Apply `/self-review` step 3 (lens walk + tooling sweep + self-critique), then validate findings per `/self-review` step 4 (Validation Rigor). Full three-pass rigor is a **hard gate** only for findings that could be routed to Auto-applicable, since Polish will silently apply those and condition 4 of `Finding Categorization` requires converged validation. For findings that already fail one of conditions 1–3 (not tool-grounded, not mechanical, or user-observable change) and can therefore only land in Needs sign-off or Needs human judgment, a **soft-floor pass** is enough: spot-check to drop clear false positives, then route to Needs sign-off or Needs human judgment. The user finishes validation during their own review of those items, so spending three full passes on them is wasted work.
 
 **Fan-out vs inline.** `/self-review` step 3 defaults to spawning one `Explore` sub-agent per canonical lens, and that default holds for any non-trivial diff. You may walk lenses inline only when **all three** of these hold; otherwise fan out:
 
-- **Doc/config dominant.** More than 80% of changed lines are in markdown, YAML, JSON, or TOML.
+- **Doc/config dominant.** More than 80% of changed lines are in markdown, YAML, JSON, TOML, or HCL (`.tf`, `.tfvars`). HCL counts as config only when the repo ships no terraform-specific linter (tflint, tfsec, checkov, OPA); if any of those exist, `.tf` counts as executable code and forces fan-out so the lens-coverage table reflects each tool's signal.
 - **Narrow code surface.** At most 2 files contain executable code (shell, Ruby, Python, Go, etc.).
 - **Modest total size.** Fewer than ~300 changed lines.
 
@@ -37,28 +37,28 @@ Inline walking does not waive any other invariant: the lens-coverage table, the 
 
 **Known false-positive patterns.** Some tool outputs look like cleanup candidates but are intentional. Drop these at discovery rather than routing them anywhere:
 
-- **Dialyzer `:unnecessary_skip` against paths outside the current env's `elixirc_paths`** (commonly `test/support/*` files surfaced when running `mix dialyzer` directly instead of `mix ci`). The skip filter is intentional CI-side coverage for code Dialyzer cannot see from the dev compile path; removing it would silently lose CI coverage. If you cannot determine whether the skip target is reachable from the current env's compile path, route to Needs human attention rather than Auto-applicable.
+- **Dialyzer `:unnecessary_skip` against paths outside the current env's `elixirc_paths`** (commonly `test/support/*` files surfaced when running `mix dialyzer` directly instead of `mix ci`). The skip filter is intentional CI-side coverage for code Dialyzer cannot see from the dev compile path; removing it would silently lose CI coverage. If you cannot determine whether the skip target is reachable from the current env's compile path, route to Needs sign-off or Needs human judgment rather than Auto-applicable.
 
 ### b. Categorize per CLAUDE.md `Finding Categorization`
 
-Each finding lands in exactly one bucket: **Auto-applicable** (all four bright-line conditions met, no disqualifiers) or **Needs human attention** (everything else). The four conditions:
+Each finding lands in exactly one bucket: **Auto-applicable** (all four bright-line conditions met, no disqualifiers), **Needs sign-off** (LLM has a single recommended fix but the change warrants human approval before landing), or **Needs human judgment** (multiple valid resolutions, missing context, or low confidence). The four Auto-applicable conditions:
 
 1. Tool-grounded (a specific linter / type-checker / formatter / static-analyzer rule was cited).
 2. Mechanical fix (rename, reformat, drop-unused, missing-import, missing-newline, typo, inferable-type-annotation; no design decision).
 3. No user-observable behavior change.
 4. All three Validation Rigor passes converged with high confidence.
 
-Plus the unconditional disqualifiers (security-sensitive code, migrations, destructive ops, CI config, lockfiles, secrets files, .env). Anything disqualified is Needs human attention regardless of how mechanical the fix looks.
+Plus the unconditional disqualifiers (security-sensitive code, migrations, destructive ops, CI config, lockfiles, secrets files, .env). Anything disqualified routes to Needs sign-off (when the LLM has a clear fix) or Needs human judgment (when the path is genuinely ambiguous); the disqualifier prevents autonomous application but does not prevent the LLM from recommending the fix. See `Finding Categorization` for full bucket definitions.
 
-Be more conservative than `/self-review` because nobody is checking the categorization in real time. **When in doubt, route to Needs human attention.** False negatives (a real Auto-applicable item routed to human) are cheap, costing one extra iteration. False positives (a judgment item auto-applied) silently corrupt the branch.
+Be more conservative than `/self-review` because nobody is checking the categorization in real time. **When in doubt, route to Needs sign-off (if you have a recommended fix) or Needs human judgment (if you do not).** False negatives (a real Auto-applicable item routed to human) are cheap, costing one extra iteration. False positives (a judgment item auto-applied) silently corrupt the branch.
 
 ### c. Decide loop fate
 
 Branch on the bucket counts:
 
-- **Both buckets empty.** Success. Exit the loop. Print the final summary noting "no findings remain". Do not commit.
-- **Auto-applicable empty, Needs human attention non-empty.** Stop. Trigger **Human attention required** stop condition. Print the latest tables and hand control back. Do not push, do not commit, do not auto-apply anything.
-- **Auto-applicable non-empty, regardless of Needs human attention count.** Proceed to step (d). Items in Needs human attention will be re-evaluated next iteration; the user can address them after Polish hands off.
+- **All three buckets empty.** Success. Exit the loop. Print the final summary noting "no findings remain". Do not commit.
+- **Auto-applicable empty, Needs sign-off or Needs human judgment non-empty.** Stop. Trigger **Human attention required** stop condition. Print the latest tables and hand control back. Do not push, do not commit, do not auto-apply anything from the populated buckets.
+- **Auto-applicable non-empty, regardless of the other buckets.** Proceed to step (d). Items in Needs sign-off and Needs human judgment will be re-evaluated next iteration; the user addresses them after Polish hands off.
 
 ### d. Apply Auto-applicable items (solution validation rigor)
 
@@ -85,7 +85,7 @@ Commit the changes from this iteration:
 Print a short summary:
 
 - Iteration N / cap
-- Counts: Auto-applicable applied, Needs human attention surfaced (carried into next iteration's input), dropped at step (d.1) (rule no longer fires)
+- Counts: Auto-applicable applied, Needs sign-off surfaced, Needs human judgment surfaced, dropped at step (d.1) (rule no longer fires)
 - Files touched
 - Commit SHA
 - Test command run + result
@@ -98,12 +98,12 @@ If any condition fires, **stop**. Print the latest tables, name the condition, a
 
 | Condition | Trigger |
 |---|---|
-| **Human attention required** | Step (c) found Needs human attention items and Auto-applicable is empty. The normal path to handoff. |
+| **Human attention required** | Step (c) found Needs sign-off or Needs human judgment items and Auto-applicable is empty. The normal path to handoff. |
 | **Test failure** | Any test, linter, type-check, or formatter failed at step (d.4), including pre-existing failures surfaced for the first time. |
 | **Loop detection** | The same Auto-applicable item has been "fixed" in two consecutive iterations (rule fires before the fix in iteration N, fires again before the fix in iteration N+1). Indicates the fix is not actually addressing the rule. |
 | **Iteration cap** | 10 iterations completed without convergence. |
-| **Ambiguity** | A finding is borderline between buckets and the four bright-line conditions cannot be confidently asserted. Always route to Needs human attention; the bucket re-evaluation in the next iteration is the safety net, but if it persists across iterations, stop. |
-| **Security-sensitive** | Any Auto-applicable candidate touches auth, secrets, crypto, permissions, IAM, SQL/shell construction, or sandbox boundaries. Per the categorization disqualifiers, the item should already be Needs human attention; if for any reason it landed in Auto-applicable, stop. |
+| **Ambiguity** | A finding is borderline between buckets and the bright-line conditions cannot be confidently asserted. Route to Needs sign-off when there is a clear recommended fix, otherwise to Needs human judgment; the bucket re-evaluation in the next iteration is the safety net, but if the ambiguity persists across iterations, stop. |
+| **Security-sensitive** | Any Auto-applicable candidate touches auth, secrets, crypto, permissions, IAM, SQL/shell construction, or sandbox boundaries. Per the categorization disqualifiers, the item should already be Needs sign-off (or Needs human judgment if the resolution is ambiguous); if for any reason it landed in Auto-applicable, stop. |
 | **Migrations / data / destructive ops** | Same as above for schema migrations, backfills, deletes, drops, anything irreversible. |
 | **Dirty working tree** | Pre-flight step 4 found uncommitted changes. Stop before iteration starts. |
 | **High false-positive ratio** | At least 3 items in the iteration AND more than half were dropped at step (d.1) (rule no longer fires). The model may be misreading the diff or hallucinating tool output. Pause for re-alignment rather than spamming useless commits. |
@@ -112,7 +112,7 @@ If any condition fires, **stop**. Print the latest tables, name the condition, a
 
 These hold at every step:
 
-- **Never** address a Needs human attention item, even if it looks easy.
+- **Never** address a Needs sign-off or Needs human judgment item, even if it looks easy.
 - **Never** route a finding to Auto-applicable without a specific rule citation. "I am sure this is a typo" does not qualify; "rubocop Style/UnlessElse" does.
 - **Never** modify CI configuration, `.env`, secrets, or lockfiles, even on a tool's recommendation.
 - **Never** push, force-push, amend, squash, or rebase. Polish is local-only; remote interaction is `/self-review`'s job.

--- a/roles/osx/files/claude/commands/self-review.md
+++ b/roles/osx/files/claude/commands/self-review.md
@@ -34,9 +34,14 @@ Do a comprehensive code review of the current feature branch.
 
    Drop or downgrade items where the three passes do not converge. Eliminate false positives and speculative concerns. Only report issues you are confident about.
 
-5. Present results: the canonical lens-coverage table from CLAUDE.md `Discovery Rigor (Issue Identification)` first, then both findings tables per CLAUDE.md `Finding Categorization`. No `Draft comment` column on either table: this skill implements fixes, it does not post per-finding comments.
+5. Present results: the canonical lens-coverage table from CLAUDE.md `Discovery Rigor (Issue Identification)` first, then the three findings tables per CLAUDE.md `Finding Categorization` (Auto-applicable, Needs sign-off, Needs human judgment, in fixed order; empty buckets get a single `none` row). No `Draft comment` column on the tables: this skill implements fixes, it does not post per-finding comments.
 
-6. Follow the standard review workflow (let me choose: all at once, one by one, batched decisions, or clustered decisions, with progress tracking). For batched mode, the `/self-review` option set is **Address now / Defer to follow-up / Dismiss / Discuss first** (with auto-added "Other" for custom decisions). For clustered mode, the cluster-wide option set is **Address all / Defer all to follow-up / Dismiss all / Pick individually** (with "Pick individually" dropping into batched mode for that cluster only). When implementing fixes, apply the **two-or-three-angle solution validation** (canonical spec in CLAUDE.md `Validation Rigor (Solutions)`):
+6. Follow the standard review workflow (let me choose: all at once, one by one, batched decisions, or clustered decisions, with progress tracking). Option sets are derived from each finding's bucket per CLAUDE.md `Finding Categorization`:
+   - **Auto-applicable**: no question, apply with solution validation (no user prompt).
+   - **Needs sign-off**: standard `Apply / Skip / Modify` option set in batched mode; `Apply all / Skip all / Pick individually` in clustered mode (auto-added "Other" in both).
+   - **Needs human judgment**: bespoke options per finding in batched mode (the skill authors the actual decision branches; generic timing options are forbidden, see `Finding Categorization` forcing function); cluster-wide options that reflect the shared axis in clustered mode.
+
+   When implementing fixes, apply the **two-or-three-angle solution validation** (canonical spec in CLAUDE.md `Validation Rigor (Solutions)`):
    - Targeted failing test for the bug's exact reason → fix → confirm test passes.
    - Run the broader test suite, linters, and type-checkers. Watch for regressions.
    - When relevant: edge cases (null, empty, max, concurrency), integration / smoke tests, or manual exercise of the user-facing flow.

--- a/roles/osx/tasks/homebrew.yml
+++ b/roles/osx/tasks/homebrew.yml
@@ -21,3 +21,34 @@
   changed_when: "'CHANGED' in osx_claude_mcp_github.stdout"
   when: lookup('ansible.builtin.env', 'CI', default='') == ''
   tags: [osx]
+
+- name: Check Ollama service state
+  ansible.builtin.shell:
+    cmd: |
+      set -o pipefail
+      brew services list | awk '/^ollama / {print $2}'
+  register: osx_ollama_service_state
+  changed_when: false
+  tags: [osx, ollama]
+
+- name: Start Ollama service
+  ansible.builtin.command:
+    cmd: brew services start ollama
+  when: osx_ollama_service_state.stdout != 'started'
+  tags: [osx, ollama]
+
+- name: List installed Ollama models
+  ansible.builtin.command:
+    cmd: ollama list
+  register: osx_ollama_models
+  changed_when: false
+  tags: [osx, ollama-models]
+
+- name: Pull Ollama panel-backend models
+  ansible.builtin.command:
+    cmd: "ollama pull {{ item }}"
+  loop:
+    - qwen2.5-coder:32b
+    - deepseek-r1:32b
+  when: item not in osx_ollama_models.stdout
+  tags: [osx, ollama-models]

--- a/roles/osx/tasks/osx.yml
+++ b/roles/osx/tasks/osx.yml
@@ -73,37 +73,6 @@
     state: link
   tags: [osx]
 
-- name: Check Ollama service state
-  ansible.builtin.shell:
-    cmd: |
-      set -o pipefail
-      brew services list | awk '/^ollama / {print $2}'
-  register: osx_ollama_service_state
-  changed_when: false
-  tags: [osx, ollama]
-
-- name: Start Ollama service
-  ansible.builtin.command:
-    cmd: brew services start ollama
-  when: osx_ollama_service_state.stdout != 'started'
-  tags: [osx, ollama]
-
-- name: List installed Ollama models
-  ansible.builtin.command:
-    cmd: ollama list
-  register: osx_ollama_models
-  changed_when: false
-  tags: [osx, ollama-models]
-
-- name: Pull Ollama panel-backend models
-  ansible.builtin.command:
-    cmd: "ollama pull {{ item }}"
-  loop:
-    - qwen2.5-coder:32b
-    - deepseek-r1:32b
-  when: item not in osx_ollama_models.stdout
-  tags: [osx, ollama-models]
-
 - name: Showing Library folder
   ansible.builtin.command:
     cmd: chflags nohidden ~/Library

--- a/roles/osx/tasks/osx.yml
+++ b/roles/osx/tasks/osx.yml
@@ -73,6 +73,37 @@
     state: link
   tags: [osx]
 
+- name: Check Ollama service state
+  ansible.builtin.shell:
+    cmd: |
+      set -o pipefail
+      brew services list | awk '/^ollama / {print $2}'
+  register: osx_ollama_service_state
+  changed_when: false
+  tags: [osx, ollama]
+
+- name: Start Ollama service
+  ansible.builtin.command:
+    cmd: brew services start ollama
+  when: osx_ollama_service_state.stdout != 'started'
+  tags: [osx, ollama]
+
+- name: List installed Ollama models
+  ansible.builtin.command:
+    cmd: ollama list
+  register: osx_ollama_models
+  changed_when: false
+  tags: [osx, ollama-models]
+
+- name: Pull Ollama panel-backend models
+  ansible.builtin.command:
+    cmd: "ollama pull {{ item }}"
+  loop:
+    - qwen2.5-coder:32b
+    - deepseek-r1:32b
+  when: item not in osx_ollama_models.stdout
+  tags: [osx, ollama-models]
+
 - name: Showing Library folder
   ansible.builtin.command:
     cmd: chflags nohidden ~/Library


### PR DESCRIPTION
## Summary

- Adds `/panel-review` (single-pass) and `/panel-pairing` (autonomous loop) that route Discovery + Validation through configurable non-Anthropic backends (Codex CLI for ChatGPT Enterprise, local Ollama models). Intended to replace `/copilot-*` once proven on real PRs; the Copilot commands stay transitional.
- Refactors Finding Categorization from 2 buckets to 3: Auto-applicable (unchanged), Needs sign-off (LLM has a recommended fix; standard `Apply / Skip / Modify`), Needs human judgment (bespoke options per finding; generic timing options forbidden via an "honest decision shape" forcing function).
- Retrofits `/self-review`, `/polish`, `/peer-review`, `/copilot-review`, `/copilot-pairing` to align option sets and tables with the new buckets. `/code-review` keeps its severity-tier presentation because it drafts comments rather than acting on findings locally.
- Installs `codex` (cask) and `ollama` (formula) via `Brewfile`. Adds idempotent Ansible tasks to start the Ollama service and pull `qwen2.5-coder:32b` and `deepseek-r1:32b`, tagged `ollama-models` for selective skipping on metered connections.
- Tightens `/polish`'s inline-walk fan-out gate so HCL (`.tf`, `.tfvars`) counts as config only when the repo ships no terraform-specific linter (tflint, tfsec, checkov, OPA); otherwise it forces fan-out so the lens-coverage table reflects each tool's signal.

## Test plan

- [ ] `mise run lint` passes (yamllint, ansible-lint production profile, syntax-check)
- [ ] `mise run osx` installs `codex` cask, `ollama` formula, starts Ollama service, pulls both models (or skips when already present)
- [ ] `codex login` succeeds against ChatGPT Enterprise on a work machine
- [ ] `/panel-review` runs end-to-end on a work repo with `codex` default backend and surfaces findings in three-bucket tables
- [ ] `/panel-review` runs end-to-end on a personal repo with `qwen-coder` default backend
- [ ] `/panel-pairing` autonomous loop converges or hits a documented stop condition on a real branch
- [ ] After 2-3 successful `/panel-*` runs on real PRs, open follow-up PR to retire `/copilot-review` and `/copilot-pairing`