### PR TITLE
fix(panel): reload Ollama LaunchAgent via launchctl, not brew services restart

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,9 +152,15 @@ The work host's IP is a DHCP reservation at `192.168.1.20`. Updates:
 generated LaunchAgent plist with `PlistBuddy` (additive: existing tuning
 keys like `OLLAMA_FLASH_ATTENTION` are preserved). Ansible also runs
 `launchctl setenv` to apply the change to the current launchd session
-without waiting for a reboot, then `brew services restart ollama` when the
-plist changed. After `brew upgrade ollama` Homebrew may regenerate the
-plist; re-running `mise run osx` re-adds the key.
+without waiting for a reboot, then reloads the LaunchAgent via
+`launchctl bootout` + `launchctl bootstrap` when the plist changed.
+**Do not use `brew services restart ollama` for this**: that command
+regenerates the plist from the formula's `service` block on every
+invocation, wiping any keys not baked into the formula
+(`OLLAMA_FLASH_ATTENTION` and `OLLAMA_KV_CACHE_TYPE` survive because the
+formula defines them; `OLLAMA_HOST` does not). Same hazard applies to
+`brew upgrade ollama`. Either way, re-run `mise run osx` to re-add the
+key.
 
 **Trust caveat:** Ollama has no auth. Binding to `0.0.0.0` exposes the
 daemon to everything on the LAN. Fine on a trusted home network; on

--- a/roles/osx/tasks/homebrew.yml
+++ b/roles/osx/tasks/homebrew.yml
@@ -84,9 +84,19 @@
   when: inventory_hostname == 'work'
   tags: [osx, ollama]
 
-- name: Restart Ollama service to pick up OLLAMA_HOST change
-  ansible.builtin.command:
-    cmd: brew services restart ollama
+# Reload via launchctl, NOT `brew services restart`. The latter regenerates
+# the plist from the formula's `service` block on every invocation, which
+# wipes the OLLAMA_HOST key we just added (the formula bakes in
+# OLLAMA_FLASH_ATTENTION and OLLAMA_KV_CACHE_TYPE, so those survive; nothing
+# we add does). bootout+bootstrap reloads the existing plist as-is.
+- name: Reload Ollama LaunchAgent to pick up OLLAMA_HOST change
+  ansible.builtin.shell:
+    cmd: |
+      set -o pipefail
+      plist="{{ ansible_env.HOME }}/Library/LaunchAgents/homebrew.mxcl.ollama.plist"
+      uid="$(id -u)"
+      launchctl bootout "gui/$uid/homebrew.mxcl.ollama" 2>/dev/null || true
+      launchctl bootstrap "gui/$uid" "$plist"
   when:
     - inventory_hostname == 'work'
     - osx_ollama_host_plist_set is changed


### PR DESCRIPTION
## Summary

- **The bug.** `roles/osx/tasks/homebrew.yml` set `OLLAMA_HOST=0.0.0.0:11434` in the brew-generated LaunchAgent plist via `PlistBuddy`, then ran `brew services restart ollama` to pick up the change. The restart regenerates the plist from the formula's `service` block on every invocation, wiping `OLLAMA_HOST` (the formula bakes in `OLLAMA_FLASH_ATTENTION` and `OLLAMA_KV_CACHE_TYPE`, so those survived; our addition did not). The daemon ended up listening on `127.0.0.1:11434` instead of `*:11434`, and `personal`/`alt` LAN clients hit "no route to host" from `/panel-*`. Verified live during the originating session: post-Ansible plist contained only the two formula-baked vars, and `lsof -nP -iTCP:11434 -sTCP:LISTEN` showed `127.0.0.1:11434`.
- **The fix** (`roles/osx/tasks/homebrew.yml`): replace `brew services restart ollama` with `launchctl bootout` + `launchctl bootstrap` of the `gui/$(id -u)/homebrew.mxcl.ollama` job, reloading the edited plist as-is. `bootout` swallows its rc with `|| true` to handle "not currently loaded"; `bootstrap` is the last command, so Ansible surfaces its failures. Matches the existing convention in `roles/services/tasks/main.yml:174` for the watchdog LaunchAgent.
- **Docs** (`CLAUDE.md`): the "Cross-host Ollama topology" note now describes the launchctl reload mechanism and flags the regeneration hazard explicitly. Both `brew services restart ollama` and `brew upgrade ollama` regenerate the plist and wipe `OLLAMA_HOST`; recovery in either case is `mise run osx`.

## Test plan

- [x] `yamllint roles/osx/tasks/homebrew.yml`, `ansible-lint roles/osx/tasks/homebrew.yml` (production profile), and `ansible-playbook main.yml --syntax-check` all clean
- [x] Live verification on the work host: after the one-off `PlistBuddy Add` + `launchctl bootout`/`bootstrap` (the same shape the Ansible task now uses), `lsof -nP -iTCP:11434 -sTCP:LISTEN` shows `*:11434 (LISTEN)` and the plist persists `OLLAMA_HOST=0.0.0.0:11434`
- [x] `mise run osx -t ollama` on the work host applies the fix without error; a second run reports `changed=0, skipped=4` (idempotent)
- [x] `/polish` and `/self-review` both ran on this branch and surfaced zero findings
- [ ] Cross-host reachability from `personal`/`alt`: `curl -sf http://192.168.1.20:11434/api/tags` after the separate WARP/LAN-routing issue flagged in the originating session is resolved (not blocked by this PR)