### PR TITLE
chore(claude): allow curl to LAN Ollama daemon without prompts

### DIFF
--- a/roles/osx/files/claude/settings.json
+++ b/roles/osx/files/claude/settings.json
@@ -57,5 +57,11 @@
     "gopls-lsp@claude-plugins-official": true,
     "rust-analyzer-lsp@claude-plugins-official": true
   },
-  "alwaysThinkingEnabled": true
+  "alwaysThinkingEnabled": true,
+  "permissions": {
+    "allow": [
+      "Bash(curl * 192.168.1.20:11434*)",
+      "Bash(curl *http://192.168.1.20:11434*)"
+    ]
+  }
 }


### PR DESCRIPTION
## Summary
- Allowlists `curl` against the work host's Ollama daemon at `192.168.1.20:11434` so `/panel-*` skills can probe it without per-call permission prompts.

## Test plan
- [ ] Re-run Ansible (`mise run osx`) and confirm the materialized `~/.claude/settings.json` carries the two new allow rules.
- [ ] Start a fresh Claude session on a client host (`personal` or `alt`) and run a `/panel-*` probe; confirm no permission prompt appears for the LAN curl.